### PR TITLE
fix: Kerberos GSSAPI, snapshot completeness, wevtutil attack detection (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix GSSAPI/Kerberos authentication failing when only domain name is known: `sasl_gssapi_bind` was receiving the domain name (e.g., `DSPANEL.LOCAL`) instead of the DC FQDN (e.g., `dc01.dspanel.local`), causing SPN mismatch. Now resolves DC FQDN via DNS SRV lookup (`_ldap._tcp.<domain>`) with LOGONSERVER fallback.
 - Fix snapshots only capturing 27 predefined attributes: `capture_snapshot()` now fetches all attributes via base-scope LDAP search with `["*"]` wildcard, ensuring Advanced Attributes edits are fully recorded for diff and restore.
+- Replace PowerShell `Get-WinEvent` with `wevtutil` for attack detection event log queries. Supports `/r:` `/u:` `/p:` `/a:Negotiate` for authenticated remote access from non-domain machines. Fixes #16.
 
 ## [1.0.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix GSSAPI/Kerberos authentication failing when only domain name is known: `sasl_gssapi_bind` was receiving the domain name (e.g., `DSPANEL.LOCAL`) instead of the DC FQDN (e.g., `dc01.dspanel.local`), causing SPN mismatch. Now resolves DC FQDN via DNS SRV lookup (`_ldap._tcp.<domain>`) with LOGONSERVER fallback.
+
 ## [1.0.0] - 2026-03-27
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix GSSAPI/Kerberos authentication failing when only domain name is known: `sasl_gssapi_bind` was receiving the domain name (e.g., `DSPANEL.LOCAL`) instead of the DC FQDN (e.g., `dc01.dspanel.local`), causing SPN mismatch. Now resolves DC FQDN via DNS SRV lookup (`_ldap._tcp.<domain>`) with LOGONSERVER fallback.
+- Fix snapshots only capturing 27 predefined attributes: `capture_snapshot()` now fetches all attributes via base-scope LDAP search with `["*"]` wildcard, ensuring Advanced Attributes edits are fully recorded for diff and restore.
 
 ## [1.0.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-03-27
+
 ### Fixed
 
 - Fix GSSAPI/Kerberos authentication failing when only domain name is known: `sasl_gssapi_bind` was receiving the domain name (e.g., `DSPANEL.LOCAL`) instead of the DC FQDN (e.g., `dc01.dspanel.local`), causing SPN mismatch. Now resolves DC FQDN via DNS SRV lookup (`_ldap._tcp.<domain>`) with LOGONSERVER fallback.
-- Fix snapshots only capturing 27 predefined attributes: `capture_snapshot()` now fetches all attributes via base-scope LDAP search with `["*"]` wildcard, ensuring Advanced Attributes edits are fully recorded for diff and restore.
-- Replace PowerShell `Get-WinEvent` with `wevtutil` for attack detection event log queries. Supports `/r:` `/u:` `/p:` `/a:Negotiate` for authenticated remote access from non-domain machines. Fixes #16.
+- Fix snapshots only capturing 27 predefined attributes: `capture_snapshot()` now fetches all attributes via base-scope LDAP search with `["*"]` wildcard, ensuring Advanced Attributes edits are fully recorded for diff and restore (#15).
+- Replace PowerShell `Get-WinEvent` with `wevtutil` for attack detection event log queries. Supports `/r:` `/u:` `/p:` `/a:Negotiate` for authenticated remote access from non-domain machines (#16).
+- Add Windows-only platform check for Attack Detection page (disabled with message on macOS/Linux).
 
 ## [1.0.0] - 2026-03-27
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Tauri-v2-blue.svg" alt="Tauri">
   <img src="https://img.shields.io/badge/Platform-Windows%20|%20macOS%20|%20Linux-0078D6.svg" alt="Platform">
-  <img src="https://img.shields.io/badge/Status-v1.0.0-brightgreen.svg" alt="Status">
+  <img src="https://img.shields.io/badge/Status-v1.0.1-brightgreen.svg" alt="Status">
   <img src="https://img.shields.io/badge/Coverage-82%25_Rust_|_87%25_TS-brightgreen.svg" alt="Coverage">
   <img src="https://img.shields.io/badge/i18n-EN%20|%20FR%20|%20DE%20|%20ES%20|%20IT-blueviolet.svg" alt="i18n">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dspanel",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "packageManager": "pnpm@10.28.1",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dspanel"
-version = "1.0.0"
+version = "1.0.1"
 description = "DSPanel - Active Directory management tool"
 authors = ["Rwx-G"]
 license = "Apache-2.0"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -69,32 +69,13 @@ async fn capture_snapshot(state: &AppState, object_dn: &str, operation: &str) {
         .authenticated_user()
         .unwrap_or_else(|| std::env::var("USERNAME").unwrap_or_else(|_| "Unknown".to_string()));
 
-    // Fetch current object attributes by extracting CN from DN and searching
-    let cn = object_dn
-        .split(',')
-        .next()
-        .and_then(|part| {
-            part.strip_prefix("CN=")
-                .or_else(|| part.strip_prefix("cn="))
-        })
-        .unwrap_or("");
-
-    let attrs_json = if !cn.is_empty() {
-        // Try user search first, then computer, then group
-        let user_result = provider.search_users(cn, 5).await;
-        let entry = user_result.ok().and_then(|entries| {
-            entries
-                .into_iter()
-                .find(|e| e.distinguished_name == object_dn)
-        });
-
-        if let Some(entry) = entry {
-            serde_json::to_string(&entry.attributes).unwrap_or_else(|_| "{}".to_string())
-        } else {
-            "{}".to_string()
+    // Fetch ALL attributes of the object (not just USER_ATTRS subset)
+    // to ensure snapshots capture every attribute that could be modified.
+    let attrs_json = match provider.get_all_attributes(object_dn).await {
+        Ok(attrs) if !attrs.is_empty() => {
+            serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
         }
-    } else {
-        "{}".to_string()
+        _ => "{}".to_string(),
     };
 
     state

--- a/src-tauri/src/services/directory.rs
+++ b/src-tauri/src/services/directory.rs
@@ -178,6 +178,15 @@ pub trait DirectoryProvider: Send + Sync {
         attributes: &std::collections::HashMap<String, Vec<String>>,
     ) -> Result<String>;
 
+    /// Fetches all attributes of an object by DN using a base-scope search with ["*"].
+    /// Used for complete snapshots before modifications.
+    async fn get_all_attributes(
+        &self,
+        _dn: &str,
+    ) -> Result<std::collections::HashMap<String, Vec<String>>> {
+        Ok(std::collections::HashMap::new())
+    }
+
     /// Modifies an attribute on an AD object.
     async fn modify_attribute(
         &self,

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -9,6 +9,62 @@ use ldap3::{LdapConnAsync, LdapConnSettings, Mod, Scope, SearchEntry};
 use crate::models::{ContactInfo, DirectoryEntry, OUNode, PrinterInfo};
 use crate::services::directory::DirectoryProvider;
 
+/// Resolves the DC FQDN from a domain name using DNS SRV lookup.
+///
+/// `sasl_gssapi_bind` needs the server FQDN for the Kerberos SPN
+/// (e.g., `ldap/dc01.corp.local`). When only the domain name is known
+/// (e.g., `corp.local` from `USERDNSDOMAIN`), this function queries
+/// `_ldap._tcp.<domain>` to find the actual DC hostname.
+///
+/// Falls back to the original host if:
+/// - The host is already a FQDN (more than 2 dot-separated parts)
+/// - DNS SRV resolution fails
+#[cfg(feature = "gssapi")]
+async fn resolve_dc_fqdn_for_gssapi(host: &str) -> String {
+    // If host already looks like a FQDN (e.g., dc01.corp.local), use it as-is
+    if host.split('.').count() > 2 {
+        return host.to_string();
+    }
+
+    // Try DNS SRV lookup: _ldap._tcp.<domain>
+    let srv_name = format!("_ldap._tcp.{}.", host);
+    tracing::debug!(srv_name = %srv_name, "Resolving DC FQDN via DNS SRV for GSSAPI");
+
+    let resolver = hickory_resolver::TokioResolver::builder_tokio()
+        .map(|b| b.build())
+        .unwrap_or_else(|_| {
+            hickory_resolver::TokioResolver::builder_with_config(
+                hickory_resolver::config::ResolverConfig::default(),
+                Default::default(),
+            )
+            .build()
+        });
+
+    match resolver.srv_lookup(&srv_name).await {
+        Ok(lookup) => {
+            if let Some(srv) = lookup.iter().next() {
+                let fqdn = srv.target().to_string();
+                let fqdn = fqdn.trim_end_matches('.').to_string();
+                tracing::info!(domain = %host, fqdn = %fqdn, "DC FQDN resolved via DNS SRV");
+                return fqdn;
+            }
+            tracing::warn!(domain = %host, "DNS SRV lookup returned no records");
+            host.to_string()
+        }
+        Err(e) => {
+            // Fallback: try LOGONSERVER env var (Windows only)
+            if let Ok(logon_server) = std::env::var("LOGONSERVER") {
+                let netbios = logon_server.trim_start_matches('\\');
+                let fqdn = format!("{}.{}", netbios, host);
+                tracing::info!(fqdn = %fqdn, "DC FQDN derived from LOGONSERVER");
+                return fqdn;
+            }
+            tracing::warn!(domain = %host, error = %e, "DNS SRV lookup failed, using domain as fallback");
+            host.to_string()
+        }
+    }
+}
+
 /// LDAP attributes to retrieve for user searches.
 const USER_ATTRS: &[&str] = &[
     "distinguishedName",
@@ -579,9 +635,15 @@ impl LdapDirectoryProvider {
             }
             LdapAuthMode::Gssapi => {
                 #[cfg(feature = "gssapi")]
-                ldap.sasl_gssapi_bind(&host)
-                    .await
-                    .context("GSSAPI (Kerberos) authentication failed")?;
+                {
+                    // sasl_gssapi_bind needs the server FQDN for the SPN (ldap/<fqdn>),
+                    // not the domain name. Resolve DC FQDN via DNS SRV lookup.
+                    let gssapi_host = resolve_dc_fqdn_for_gssapi(&host).await;
+                    tracing::debug!(gssapi_host = %gssapi_host, original_host = %host, "GSSAPI bind with resolved FQDN");
+                    ldap.sasl_gssapi_bind(&gssapi_host)
+                        .await
+                        .context("GSSAPI (Kerberos) authentication failed")?;
+                }
 
                 #[cfg(not(feature = "gssapi"))]
                 ldap.simple_bind("", "")
@@ -881,9 +943,12 @@ async fn create_fresh_connection(
         }
         LdapAuthMode::Gssapi => {
             #[cfg(feature = "gssapi")]
-            ldap.sasl_gssapi_bind(&host)
-                .await
-                .context("GSSAPI authentication failed")?;
+            {
+                let gssapi_host = resolve_dc_fqdn_for_gssapi(&host).await;
+                ldap.sasl_gssapi_bind(&gssapi_host)
+                    .await
+                    .context("GSSAPI authentication failed")?;
+            }
 
             #[cfg(not(feature = "gssapi"))]
             ldap.simple_bind("", "")

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -1888,6 +1888,32 @@ impl DirectoryProvider for LdapDirectoryProvider {
         Ok(dn)
     }
 
+    async fn get_all_attributes(
+        &self,
+        dn: &str,
+    ) -> Result<std::collections::HashMap<String, Vec<String>>> {
+        let dn_owned = dn.to_string();
+        self.with_connection(|mut ldap| {
+            let dn = dn_owned.clone();
+            async move {
+                let (rs, _) = ldap
+                    .search(&dn, ldap3::Scope::Base, "(objectClass=*)", vec!["*"])
+                    .await
+                    .context("Failed to fetch all attributes")?
+                    .success()
+                    .context("All-attributes search returned error")?;
+
+                if let Some(entry) = rs.into_iter().next() {
+                    let se = ldap3::SearchEntry::construct(entry);
+                    Ok(se.attrs)
+                } else {
+                    Ok(std::collections::HashMap::new())
+                }
+            }
+        })
+        .await
+    }
+
     async fn modify_attribute(
         &self,
         dn: &str,

--- a/src-tauri/src/services/security.rs
+++ b/src-tauri/src/services/security.rs
@@ -3077,39 +3077,47 @@ pub async fn detect_attacks(
 ///
 /// Uses `Get-WinEvent -MaxEvents 1` as a language-independent access check.
 #[cfg(target_os = "windows")]
-/// Builds a PowerShell credential snippet from bind DN and password.
-/// Converts DN format "CN=User,CN=Users,DC=domain,DC=local" to "domain.local\User".
+/// Extracts domain\username from a bind DN for wevtutil authentication.
+/// Converts "CN=User,CN=Users,DC=domain,DC=local" to "domain.local\User".
 #[cfg(target_os = "windows")]
-fn build_credential_param(bind_dn: &str, password: &str) -> String {
-    // Extract username from CN=...
+fn dn_to_domain_user(bind_dn: &str) -> String {
     let username = bind_dn
         .split(',')
         .next()
         .and_then(|rdn| rdn.strip_prefix("CN="))
         .unwrap_or(bind_dn);
-
-    // Extract domain from DC= components
     let domain: String = bind_dn
         .split(',')
         .filter_map(|part| part.strip_prefix("DC="))
         .collect::<Vec<_>>()
         .join(".");
-
-    let user = if domain.is_empty() {
+    if domain.is_empty() {
         username.to_string()
     } else {
         format!("{}\\{}", domain, username)
-    };
-
-    // Escape single quotes in password
-    let escaped_pwd = password.replace('\'', "''");
-
-    format!(
-        "$cred=New-Object System.Management.Automation.PSCredential('{}',('{}' | ConvertTo-SecureString -AsPlainText -Force));",
-        user, escaped_pwd
-    )
+    }
 }
 
+/// Builds wevtutil remote arguments: /r:<host> /u:<user> /p:<pass> /a:Negotiate
+#[cfg(target_os = "windows")]
+fn wevtutil_remote_args(
+    dc_host: Option<&str>,
+    credentials: Option<&(String, String)>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(host) = dc_host {
+        args.push(format!("/r:{}", host));
+    }
+    if let Some((bind_dn, password)) = credentials {
+        args.push(format!("/u:{}", dn_to_domain_user(bind_dn)));
+        args.push(format!("/p:{}", password));
+        args.push("/a:Negotiate".to_string());
+    }
+    args
+}
+
+/// Probes whether the Security event log is accessible on the target DC.
+/// Uses `wevtutil qe` with `/c:1` for a language-independent access check.
 #[cfg(target_os = "windows")]
 fn can_read_security_log(dc_host: Option<&str>, credentials: Option<&(String, String)>) -> bool {
     use std::process::Command;
@@ -3119,52 +3127,118 @@ fn can_read_security_log(dc_host: Option<&str>, credentials: Option<&(String, St
         return false;
     };
 
-    let cred_setup = credentials
-        .map(|(dn, pwd)| build_credential_param(dn, pwd))
-        .unwrap_or_default();
-    let cred_param = if credentials.is_some() {
-        " -Credential $cred"
-    } else {
-        ""
-    };
+    let mut args = vec![
+        "qe".to_string(),
+        "Security".to_string(),
+        "/c:1".to_string(),
+        "/f:text".to_string(),
+    ];
+    args.extend(wevtutil_remote_args(Some(host), credentials));
 
-    let cmd = format!(
-        "{}try{{Get-WinEvent -LogName Security -ComputerName '{}'{} -MaxEvents 1 -EA Stop | Out-Null;'true'}}catch{{$_.Exception.Message}}",
-        cred_setup, host, cred_param
-    );
     tracing::debug!(
         dc_host = host,
         has_credentials = credentials.is_some(),
-        "Probing remote Security event log access"
+        "Probing Security event log via wevtutil"
     );
 
-    match Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &cmd])
-        .output()
-    {
+    match Command::new("wevtutil").args(&args).output() {
         Ok(o) => {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            let result = stdout.trim();
-            if result == "true" {
-                tracing::info!(dc_host = host, "Security event log accessible");
+            if o.status.success() {
+                tracing::info!(dc_host = host, "Security event log accessible via wevtutil");
                 return true;
             }
+            let stderr = String::from_utf8_lossy(&o.stderr);
             tracing::warn!(
                 dc_host = host,
-                error = %result,
-                "Security event log probe failed - ensure 'Remote Event Log Management' firewall rule is enabled on the DC"
+                stderr = %stderr.trim(),
+                "wevtutil probe failed"
             );
             false
         }
         Err(e) => {
-            tracing::warn!(error = %e, "Failed to run PowerShell for event log probe");
+            tracing::warn!(error = %e, "Failed to run wevtutil");
             false
         }
     }
 }
 
-/// Runs a PowerShell query for a batch of event IDs and returns parsed event records.
-/// When `dc_host` is provided, queries the remote DC's Security log via `-ComputerName`.
+/// Parses a single `<Event>` XML element from wevtutil output into an EventRecord.
+#[cfg(target_os = "windows")]
+fn parse_wevtutil_event(event_xml: &str) -> Option<EventRecord> {
+    // Extract System/TimeCreated SystemTime attribute
+    let time_created = extract_xml_attr(event_xml, "TimeCreated", "SystemTime");
+    // Extract System/EventID text
+    let id = extract_xml_text(event_xml, "EventID").and_then(|s| s.parse::<u32>().ok());
+    // Extract EventData/Data elements by Name attribute
+    let data = |name: &str| extract_event_data(event_xml, name);
+
+    Some(EventRecord {
+        time_created,
+        id,
+        ip_address: data("IpAddress"),
+        target_user_name: data("TargetUserName"),
+        ticket_encryption_type: data("TicketEncryptionType"),
+        service_name: data("ServiceName"),
+        status: data("Status"),
+        sub_status: data("SubStatus"),
+        logon_type: data("LogonType"),
+        authentication_package_name: data("AuthenticationPackageName"),
+        key_length: data("KeyLength"),
+        object_type: data("ObjectType"),
+        access_mask: data("AccessMask"),
+        subject_user_name: data("SubjectUserName"),
+        attribute_ldap_display_name: data("AttributeLDAPDisplayName"),
+        object_dn: data("ObjectDN"),
+    })
+}
+
+/// Extracts an XML attribute value: `<Tag AttrName="value"` -> `value`
+#[cfg(target_os = "windows")]
+fn extract_xml_attr(xml: &str, tag: &str, attr: &str) -> Option<String> {
+    let pattern = format!("<{}", tag);
+    let tag_start = xml.find(&pattern)?;
+    let rest = &xml[tag_start..];
+    let attr_pattern = format!("{}='", attr);
+    let attr_pattern2 = format!("{}=\"", attr);
+    let attr_start = rest
+        .find(&attr_pattern)
+        .map(|p| p + attr_pattern.len())
+        .or_else(|| rest.find(&attr_pattern2).map(|p| p + attr_pattern2.len()))?;
+    let value_rest = &rest[attr_start..];
+    let end = value_rest.find(['\'', '"'])?;
+    Some(value_rest[..end].to_string())
+}
+
+/// Extracts text content of an XML element: `<Tag>text</Tag>` -> `text`
+#[cfg(target_os = "windows")]
+fn extract_xml_text(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    let text = xml[start..end].trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Extracts EventData/Data value by Name attribute:
+/// `<Data Name="IpAddress">10.0.0.1</Data>` -> `Some("10.0.0.1")`
+#[cfg(target_os = "windows")]
+fn extract_event_data(xml: &str, name: &str) -> Option<String> {
+    let pattern = format!("Name='{}'", name);
+    let pattern2 = format!("Name=\"{}\"", name);
+    let attr_pos = xml.find(&pattern).or_else(|| xml.find(&pattern2))?;
+    let rest = &xml[attr_pos..];
+    let gt = rest.find('>')?;
+    let value_start = gt + 1;
+    let value_rest = &rest[value_start..];
+    let end = value_rest.find('<')?;
+    let text = value_rest[..end].trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Queries the Security event log via `wevtutil qe` with XPath filtering.
+/// Returns parsed EventRecord structs. Uses `/r:` `/u:` `/p:` `/a:Negotiate`
+/// for remote+authenticated access (works from non-domain machines).
 #[cfg(target_os = "windows")]
 fn query_events(
     event_ids: &[u32],
@@ -3174,79 +3248,56 @@ fn query_events(
 ) -> Vec<EventRecord> {
     use std::process::Command;
 
-    let ids_str = event_ids
+    // Build XPath filter: *[System[(EventID=4768 or EventID=4769) and TimeCreated[timediff(@SystemTime) <= N]]]
+    let id_filter = event_ids
         .iter()
-        .map(|id| id.to_string())
+        .map(|id| format!("EventID={}", id))
         .collect::<Vec<_>>()
-        .join(",");
-
-    let computer_param = dc_host
-        .map(|h| format!("-ComputerName '{}'", h))
-        .unwrap_or_default();
-
-    let cred_setup = credentials
-        .map(|(dn, pwd)| build_credential_param(dn, pwd))
-        .unwrap_or_default();
-    let cred_param = if credentials.is_some() {
-        " -Credential $cred"
-    } else {
-        ""
-    };
-
-    let query = format!(
-        r#"{cred_init}Get-WinEvent -FilterHashtable @{{LogName='Security';Id={ids};StartTime=(Get-Date).AddHours(-{hours})}} {computer}{cred_arg} -MaxEvents 200 -ErrorAction SilentlyContinue | ForEach-Object {{
-    $xml = [xml]$_.ToXml()
-    $data = @{{}}
-    $xml.Event.EventData.Data | ForEach-Object {{ $data[$_.Name] = $_.'#text' }}
-    [PSCustomObject]@{{
-        TimeCreated = $_.TimeCreated.ToString('o')
-        Id = $_.Id
-        IpAddress = $data['IpAddress']
-        TargetUserName = $data['TargetUserName']
-        TicketEncryptionType = $data['TicketEncryptionType']
-        ServiceName = $data['ServiceName']
-        Status = $data['Status']
-        SubStatus = $data['SubStatus']
-        LogonType = $data['LogonType']
-        AuthenticationPackageName = $data['AuthenticationPackageName']
-        KeyLength = $data['KeyLength']
-        ObjectType = $data['ObjectType']
-        AccessMask = $data['AccessMask']
-        SubjectUserName = $data['SubjectUserName']
-        AttributeLDAPDisplayName = $data['AttributeLDAPDisplayName']
-        ObjectDN = $data['ObjectDN']
-    }}
-}} | ConvertTo-Json -Compress"#,
-        cred_init = cred_setup,
-        ids = ids_str,
-        hours = time_window_hours,
-        computer = computer_param,
-        cred_arg = cred_param,
+        .join(" or ");
+    let time_ms = time_window_hours as u64 * 3_600_000;
+    let xpath = format!(
+        "*[System[({}) and TimeCreated[timediff(@SystemTime) <= {}]]]",
+        id_filter, time_ms
     );
 
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &query])
-        .output();
+    let mut args = vec![
+        "qe".to_string(),
+        "Security".to_string(),
+        format!("/q:{}", xpath),
+        "/f:XML".to_string(),
+        "/c:200".to_string(),
+    ];
+    args.extend(wevtutil_remote_args(dc_host, credentials));
 
-    let output = match output {
+    let output = match Command::new("wevtutil").args(&args).output() {
         Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            if !stderr.trim().is_empty() {
+                tracing::warn!(stderr = %stderr.trim(), "wevtutil query returned error");
+            }
+            return Vec::new();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to run wevtutil");
+            return Vec::new();
+        }
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let trimmed = stdout.trim();
-    if trimmed.is_empty() || trimmed == "null" {
+    if stdout.trim().is_empty() {
         return Vec::new();
     }
 
-    // PowerShell returns a single object (not array) when there's exactly one result.
-    if trimmed.starts_with('[') {
-        serde_json::from_str::<Vec<EventRecord>>(trimmed).unwrap_or_default()
-    } else {
-        serde_json::from_str::<EventRecord>(trimmed)
-            .map(|r| vec![r])
-            .unwrap_or_default()
-    }
+    // wevtutil outputs consecutive <Event>...</Event> blocks (no root element)
+    stdout
+        .split("<Event xmlns")
+        .skip(1) // first split is empty or preamble
+        .filter_map(|chunk| {
+            let event_xml = format!("<Event xmlns{}", chunk);
+            parse_wevtutil_event(&event_xml)
+        })
+        .collect()
 }
 
 /// Analyzes Windows Security event log for attack indicators using structured parsing.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSPanel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.mibu.dspanel",
   "build": {
     "beforeDevCommand": "npx pnpm dev",

--- a/src/locales/de/attackDetection.json
+++ b/src/locales/de/attackDetection.json
@@ -39,5 +39,7 @@
   "timeWindow": "Zeitfenster",
   "disclaimer.checks": "14 Angriffstypen über Windows-Sicherheitsereignisprotokoll (XML-Analyse): Golden Ticket, DCSync, DCShadow, Kerberoasting, AS-REP Roasting, Brute Force, Pass-the-Hash, Passwort-Spray, Shadow Credentials, RBCD-Missbrauch, AdminSDHolder-Manipulation und mehr. MITRE ATT&CK zugeordnet.",
   "disclaimer.limitations": "Nur On-Demand-Scan (nicht Echtzeit). Liest lokales DC-Ereignisprotokoll - fragt keine Remote-DCs ab. Erfordert Windows. Erkennt kein NTLM-Relay, Skeleton Key, LSASS-Dumps oder laterale Bewegung.",
-  "disclaimer.tools": "Microsoft Defender for Identity (Echtzeit, ca. 30 Angriffstypen), CrowdStrike Falcon Identity oder Tenable Identity Exposure für kontinuierliche Überwachung."
+  "disclaimer.tools": "Microsoft Defender for Identity (Echtzeit, ca. 30 Angriffstypen), CrowdStrike Falcon Identity oder Tenable Identity Exposure für kontinuierliche Überwachung.",
+  "windowsOnly": "Nur Windows",
+  "windowsOnlyDescription": "Die Angriffserkennung analysiert Windows-Sicherheitsereignisprotokolle und ist nur verfügbar, wenn DSPanel unter Windows ausgeführt wird."
 }

--- a/src/locales/en/attackDetection.json
+++ b/src/locales/en/attackDetection.json
@@ -39,5 +39,7 @@
   "timeWindow": "Time window",
   "disclaimer.checks": "14 attack types via Windows Security Event Log (XML parsing): Golden Ticket, DCSync, DCShadow, Kerberoasting, AS-REP Roasting, Brute Force, Pass-the-Hash, Password Spray, Shadow Credentials, RBCD Abuse, AdminSDHolder Tampering, and more. MITRE ATT&CK mapped.",
   "disclaimer.limitations": "On-demand scanning only (not real-time). Reads local DC event log - does not query remote DCs. Requires Windows. Does not detect NTLM relay, Skeleton Key, LSASS dumps, or lateral movement.",
-  "disclaimer.tools": "Microsoft Defender for Identity (real-time, ~30 attack types), CrowdStrike Falcon Identity, or Tenable Identity Exposure for continuous monitoring."
+  "disclaimer.tools": "Microsoft Defender for Identity (real-time, ~30 attack types), CrowdStrike Falcon Identity, or Tenable Identity Exposure for continuous monitoring.",
+  "windowsOnly": "Windows Only",
+  "windowsOnlyDescription": "Attack Detection analyzes Windows Security Event Logs and is only available when DSPanel runs on Windows."
 }

--- a/src/locales/es/attackDetection.json
+++ b/src/locales/es/attackDetection.json
@@ -39,5 +39,7 @@
   "timeWindow": "Ventana de tiempo",
   "disclaimer.checks": "14 tipos de ataque mediante el registro de eventos de seguridad de Windows (análisis XML): Golden Ticket, DCSync, DCShadow, Kerberoasting, AS-REP Roasting, Fuerza bruta, Pass-the-Hash, Password Spray, Shadow Credentials, Abuso RBCD, Manipulación AdminSDHolder y más. Mapeado MITRE ATT&CK.",
   "disclaimer.limitations": "Solo escaneo bajo demanda (no en tiempo real). Lee el registro de eventos local del DC - no consulta DCs remotos. Requiere Windows. No detecta retransmisión NTLM, Skeleton Key, volcados LSASS ni movimiento lateral.",
-  "disclaimer.tools": "Microsoft Defender for Identity (tiempo real, aproximadamente 30 tipos de ataque), CrowdStrike Falcon Identity o Tenable Identity Exposure para monitorización continua."
+  "disclaimer.tools": "Microsoft Defender for Identity (tiempo real, aproximadamente 30 tipos de ataque), CrowdStrike Falcon Identity o Tenable Identity Exposure para monitorización continua.",
+  "windowsOnly": "Solo Windows",
+  "windowsOnlyDescription": "La detección de ataques analiza los registros de eventos de seguridad de Windows y solo está disponible cuando DSPanel se ejecuta en Windows."
 }

--- a/src/locales/fr/attackDetection.json
+++ b/src/locales/fr/attackDetection.json
@@ -39,5 +39,7 @@
   "timeWindow": "Fenêtre de temps",
   "disclaimer.checks": "14 types d'attaques via le journal d'événements de sécurité Windows (analyse XML) : Golden Ticket, DCSync, DCShadow, Kerberoasting, AS-REP Roasting, Force brute, Pass-the-Hash, Password Spray, Shadow Credentials, Abus RBCD, Falsification AdminSDHolder, et plus. Mappé MITRE ATT&CK.",
   "disclaimer.limitations": "Analyse à la demande uniquement (pas en temps réel). Lit le journal d'événements local du DC - n'interroge pas les DC distants. Nécessite Windows. Ne détecte pas le relais NTLM, Skeleton Key, les dumps LSASS, ni les mouvements latéraux.",
-  "disclaimer.tools": "Microsoft Defender for Identity (temps réel, environ 30 types d'attaques), CrowdStrike Falcon Identity ou Tenable Identity Exposure pour une surveillance continue."
+  "disclaimer.tools": "Microsoft Defender for Identity (temps réel, environ 30 types d'attaques), CrowdStrike Falcon Identity ou Tenable Identity Exposure pour une surveillance continue.",
+  "windowsOnly": "Windows uniquement",
+  "windowsOnlyDescription": "La détection d'attaques analyse les journaux d'événements de sécurité Windows et n'est disponible que lorsque DSPanel s'exécute sous Windows."
 }

--- a/src/locales/it/attackDetection.json
+++ b/src/locales/it/attackDetection.json
@@ -39,5 +39,7 @@
   "timeWindow": "Finestra temporale",
   "disclaimer.checks": "14 tipi di attacco tramite registro eventi di sicurezza Windows (analisi XML): Golden Ticket, DCSync, DCShadow, Kerberoasting, AS-REP Roasting, Forza bruta, Pass-the-Hash, Password Spray, Shadow Credentials, Abuso RBCD, Manomissione AdminSDHolder e altro. Mappato MITRE ATT&CK.",
   "disclaimer.limitations": "Solo scansione su richiesta (non in tempo reale). Legge il registro eventi locale del DC - non interroga DC remoti. Richiede Windows. Non rileva relay NTLM, Skeleton Key, dump LSASS né movimento laterale.",
-  "disclaimer.tools": "Microsoft Defender for Identity (tempo reale, circa 30 tipi di attacco), CrowdStrike Falcon Identity o Tenable Identity Exposure per il monitoraggio continuo."
+  "disclaimer.tools": "Microsoft Defender for Identity (tempo reale, circa 30 tipi di attacco), CrowdStrike Falcon Identity o Tenable Identity Exposure per il monitoraggio continuo.",
+  "windowsOnly": "Solo Windows",
+  "windowsOnlyDescription": "Il rilevamento degli attacchi analizza i registri eventi di sicurezza di Windows ed è disponibile solo quando DSPanel viene eseguito su Windows."
 }

--- a/src/pages/AttackDetection.test.tsx
+++ b/src/pages/AttackDetection.test.tsx
@@ -79,6 +79,11 @@ const mockReport: AttackDetectionReport = {
 describe("AttackDetection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: return "windows" for platform check, pending for everything else
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_platform") return Promise.resolve("windows");
+      return new Promise(() => {});
+    });
   });
 
   it("shows loading state initially", () => {
@@ -88,7 +93,7 @@ describe("AttackDetection", () => {
   });
 
   it("calls detect_ad_attacks with default time window on mount", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -99,7 +104,7 @@ describe("AttackDetection", () => {
   });
 
   it("renders alert cards after loading", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -119,7 +124,7 @@ describe("AttackDetection", () => {
   });
 
   it("displays attack type badges including new types", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -133,7 +138,7 @@ describe("AttackDetection", () => {
   });
 
   it("displays severity summary badges", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -146,7 +151,7 @@ describe("AttackDetection", () => {
   });
 
   it("displays MITRE ATT&CK reference badges", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -161,12 +166,12 @@ describe("AttackDetection", () => {
   });
 
   it("shows all checks as clear when no alerts", async () => {
-    mockInvoke.mockResolvedValue({
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve({
       alerts: [],
       timeWindowHours: 24,
       scannedAt: "2026-03-23T10:00:00Z",
       eventLogAccessible: true,
-    });
+    }));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -179,7 +184,7 @@ describe("AttackDetection", () => {
   });
 
   it("shows error state on failure", async () => {
-    mockInvoke.mockRejectedValue("Connection failed");
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.reject("Connection failed"));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -188,7 +193,7 @@ describe("AttackDetection", () => {
   });
 
   it("expands alert card to show recommendation", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -209,7 +214,7 @@ describe("AttackDetection", () => {
   });
 
   it("changes time window and re-fetches", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -228,7 +233,7 @@ describe("AttackDetection", () => {
   });
 
   it("scan button triggers re-fetch", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {
@@ -237,14 +242,17 @@ describe("AttackDetection", () => {
 
     fireEvent.click(screen.getByTestId("scan-button"));
 
-    // Initial call + scan button call
+    // Initial call + scan button call (excluding get_platform calls)
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledTimes(2);
+      const attackCalls = mockInvoke.mock.calls.filter(
+        (c) => c[0] === "detect_ad_attacks",
+      );
+      expect(attackCalls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
   it("displays source and event ID on alert cards", async () => {
-    mockInvoke.mockResolvedValue(mockReport);
+    mockInvoke.mockImplementation((cmd: string) => cmd === "get_platform" ? Promise.resolve("windows") : Promise.resolve(mockReport));
     render(<AttackDetection />);
 
     await waitFor(() => {

--- a/src/pages/AttackDetection.tsx
+++ b/src/pages/AttackDetection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { EmptyState } from "@/components/common/EmptyState";
+import { usePlatform } from "@/hooks/usePlatform";
 import {
   RefreshCw,
   ShieldCheck,
@@ -166,14 +167,17 @@ function AlertCard({
 
 export function AttackDetection() {
   const { t } = useTranslation(["attackDetection", "common"]);
+  const platform = usePlatform();
   const [report, setReport] = useState<AttackDetectionReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [timeWindowHours, setTimeWindowHours] = useState(72);
   const [expandedAlerts, setExpandedAlerts] = useState<Set<string>>(new Set());
+  const isWindows = !platform || platform === "windows";
 
   const fetchReport = useCallback(
     async (hours: number) => {
+      if (!isWindows) return;
       try {
         setError(null);
         const data = await invoke<AttackDetectionReport>("detect_ad_attacks", {
@@ -186,12 +190,26 @@ export function AttackDetection() {
         setLoading(false);
       }
     },
-    [],
+    [isWindows],
   );
 
   useEffect(() => {
-    fetchReport(timeWindowHours);
-  }, [fetchReport, timeWindowHours]);
+    if (isWindows) {
+      fetchReport(timeWindowHours);
+    }
+  }, [fetchReport, timeWindowHours, isWindows]);
+
+  if (!isWindows) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <EmptyState
+          icon={<ShieldCheck size={48} />}
+          title={t("windowsOnly")}
+          description={t("windowsOnlyDescription")}
+        />
+      </div>
+    );
+  }
 
   const handleScan = () => {
     setLoading(true);


### PR DESCRIPTION
## Summary

- Fix Kerberos/GSSAPI authentication failing on domain-joined machines
- Fix snapshots only capturing 27 attributes instead of all (#15)
- Replace PowerShell Get-WinEvent with wevtutil for cross-auth event log access (#16)
- Add Windows-only platform check for Attack Detection
- Bump to v1.0.1

## Changes

### Kerberos GSSAPI fix

`sasl_gssapi_bind()` was receiving the domain name (`DSPANEL.LOCAL` from `USERDNSDOMAIN`) instead of the DC FQDN (`dc01.dspanel.local`). This caused a Kerberos SPN mismatch (`ldap/DSPANEL.LOCAL` does not exist in the KDC).

Now resolves the DC FQDN before binding:
1. DNS SRV lookup (`_ldap._tcp.<domain>`) via hickory-resolver
2. Fallback to `LOGONSERVER` env var (Windows)
3. Fallback to domain name as last resort

### Snapshot completeness (Closes #15)

`capture_snapshot()` was using `search_users()` which only fetches 27 predefined attributes (`USER_ATTRS`). Attributes edited via Advanced Attributes (description, mobile, extensionAttribute*, etc.) were never recorded in snapshots.

Now uses a new `get_all_attributes()` method that performs a base-scope LDAP search with `["*"]` wildcard on the target DN.

### wevtutil for Attack Detection (Closes #16)

`Get-WinEvent -ComputerName` uses RPC which fails from non-domain machines. Replaced with `wevtutil qe` which supports `/r:` `/u:` `/p:` `/a:Negotiate` for authenticated remote access without PowerShell remoting.

Also added a Windows-only platform check: Attack Detection page shows a disabled state with message on macOS/Linux instead of failing silently.

## Test plan

- [x] 1520 Rust unit tests pass
- [x] 172 translation tests pass (new keys for windowsOnly)
- [x] TypeScript strict mode - no errors
- [x] Cargo clippy clean
- [x] Cargo fmt clean