### PR TITLE
Fix/kerberos error visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.2] - 2026-03-28
+### Added
+
+- Surface the cause of failed directory connections on the dashboard: when `Active Directory` shows `Disconnected`, the card now renders a localized hint explaining why (clock skew, missing Kerberos ticket, DNS SRV failure, LDAP signing requirement, TLS handshake error, authentication refused, network unreachable, etc.). Full technical error chain is written to the log at ERROR level; the UI intentionally shows only the category so support copy-paste stays manageable.
+- `DomainInfo` now carries a `connection_error` field (stable classification key, omitted when connected). A new `last_connection_error()` method on `DirectoryProvider` backs it.
+
+### Changed
+
+- GSSAPI bind logs are promoted from DEBUG to INFO: `original_host`, `gssapi_host`, computed `spn` (`ldap/<fqdn>`) and `LOGONSERVER` are now visible in the default application log, making Kerberos diagnostics possible without toggling `RUST_LOG=debug`. On failure, the full `anyhow::Error` chain is logged at ERROR level.
+
+
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-04-23
+
 ### Added
 
 - Surface the cause of failed directory connections on the dashboard: when `Active Directory` shows `Disconnected`, the card now renders a localized hint explaining why (clock skew, missing Kerberos ticket, DNS SRV failure, LDAP signing requirement, TLS handshake error, authentication refused, network unreachable, etc.). Full technical error chain is written to the log at ERROR level; the UI intentionally shows only the category so support copy-paste stays manageable.
@@ -16,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GSSAPI bind logs are promoted from DEBUG to INFO: `original_host`, `gssapi_host`, computed `spn` (`ldap/<fqdn>`) and `LOGONSERVER` are now visible in the default application log, making Kerberos diagnostics possible without toggling `RUST_LOG=debug`. On failure, the full `anyhow::Error` chain is logged at ERROR level.
 - `classify_bind_error` now recognizes the Microsoft-localized SSPI error strings for French, German, Italian and Spanish in addition to English, so the UI hint stays precise on non-English Windows hosts (where `FormatMessageW(LANG_NEUTRAL)` returns text in the OS UI language). Accent folding is applied before matching so ASCII patterns hit accented text.
+
+### Fixed
+
+- Satisfy clippy lints promoted to errors in Rust 1.95 (`unnecessary_sort_by`, `collapsible_match`) in pre-existing code touched by the CI pipeline. Semantically equivalent refactors in `ldap_directory.rs`, `preset.rs`, `replication.rs`, `replication_status.rs`.
+- `evaluate_health_cmd` tests now generate input dates relative to `Utc::now()` so the healthy-user case no longer drifts into `Inactive30Days` warning territory as real time advances past the hard-coded 2026-03 timestamps.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - GSSAPI bind logs are promoted from DEBUG to INFO: `original_host`, `gssapi_host`, computed `spn` (`ldap/<fqdn>`) and `LOGONSERVER` are now visible in the default application log, making Kerberos diagnostics possible without toggling `RUST_LOG=debug`. On failure, the full `anyhow::Error` chain is logged at ERROR level.
+- `classify_bind_error` now recognizes the Microsoft-localized SSPI error strings for French, German, Italian and Spanish in addition to English, so the UI hint stays precise on non-English Windows hosts (where `FormatMessageW(LANG_NEUTRAL)` returns text in the OS UI language). Accent folding is applied before matching so ASCII patterns hit accented text.
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Tauri-v2-blue.svg" alt="Tauri">
   <img src="https://img.shields.io/badge/Platform-Windows%20|%20macOS%20|%20Linux-0078D6.svg" alt="Platform">
-  <img src="https://img.shields.io/badge/Status-v1.0.2-brightgreen.svg" alt="Status">
+  <img src="https://img.shields.io/badge/Status-v1.0.3-brightgreen.svg" alt="Status">
   <img src="https://img.shields.io/badge/Coverage-82%25_Rust_|_87%25_TS-brightgreen.svg" alt="Coverage">
   <img src="https://img.shields.io/badge/i18n-EN%20|%20FR%20|%20DE%20|%20ES%20|%20IT-blueviolet.svg" alt="i18n">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dspanel",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "packageManager": "pnpm@10.28.1",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dspanel"
-version = "1.0.2"
+version = "1.0.3"
 description = "DSPanel - Active Directory management tool"
 authors = ["Rwx-G"]
 license = "Apache-2.0"

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -1010,17 +1010,30 @@ mod tests {
     // evaluate_health_cmd tests
     // -----------------------------------------------------------------------
 
+    /// Returns an ISO 8601 UTC timestamp `days` days before `now`.
+    ///
+    /// Used by health tests that hit the real `Utc::now()` through
+    /// `evaluate_health_cmd`, so assertions stay stable regardless of when
+    /// the suite runs.
+    fn days_ago_iso(days: i64) -> String {
+        let ts = chrono::Utc::now() - chrono::Duration::days(days);
+        ts.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    }
+
     #[test]
     fn test_evaluate_health_cmd_healthy_user() {
         let input = HealthInput {
             enabled: true,
             locked_out: false,
             account_expires: None,
-            password_last_set: Some("2026-03-01T10:00:00Z".to_string()),
+            // Password set 30 days ago - distinct from when_created, not stale
+            password_last_set: Some(days_ago_iso(30)),
             password_expired: false,
             password_never_expires: false,
-            last_logon: Some("2026-03-12T08:00:00Z".to_string()),
-            when_created: Some("2024-01-01T00:00:00Z".to_string()),
+            // Logon 5 days ago - well under the 30-day Inactive30Days threshold
+            last_logon: Some(days_ago_iso(5)),
+            // Account created 1 year ago - not recent, not co-created with password
+            when_created: Some(days_ago_iso(365)),
         };
         let result = evaluate_health_cmd(input);
         assert_eq!(result.level, crate::services::HealthLevel::Healthy);
@@ -1033,11 +1046,11 @@ mod tests {
             enabled: false,
             locked_out: false,
             account_expires: None,
-            password_last_set: Some("2026-03-01T10:00:00Z".to_string()),
+            password_last_set: Some(days_ago_iso(30)),
             password_expired: false,
             password_never_expires: false,
-            last_logon: Some("2026-03-12T08:00:00Z".to_string()),
-            when_created: Some("2024-01-01T00:00:00Z".to_string()),
+            last_logon: Some(days_ago_iso(5)),
+            when_created: Some(days_ago_iso(365)),
         };
         let result = evaluate_health_cmd(input);
         assert_eq!(result.level, crate::services::HealthLevel::Critical);

--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -244,6 +244,7 @@ pub(crate) fn get_domain_info_inner(state: &AppState) -> DomainInfo {
     DomainInfo {
         domain_name: provider.domain_name().map(|s| s.to_string()),
         is_connected: provider.is_connected(),
+        connection_error: provider.last_connection_error(),
     }
 }
 
@@ -810,6 +811,15 @@ mod tests {
         let info = get_domain_info_inner(&state);
         assert!(info.domain_name.is_none());
         assert!(!info.is_connected);
+        assert_eq!(info.connection_error.as_deref(), Some("not_domain_joined"));
+    }
+
+    #[test]
+    fn test_get_domain_info_surfaces_connection_error_kind() {
+        let provider = Arc::new(MockDirectoryProvider::new().with_connection_error("clock_skew"));
+        let state = AppState::new_for_test(provider, PermissionConfig::default());
+        let info = get_domain_info_inner(&state);
+        assert_eq!(info.connection_error.as_deref(), Some("clock_skew"));
     }
 
     #[test]
@@ -817,6 +827,7 @@ mod tests {
         let info = DomainInfo {
             domain_name: Some("CORP.LOCAL".to_string()),
             is_connected: true,
+            connection_error: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("domain_name"));
@@ -1173,10 +1184,12 @@ mod tests {
         let info = DomainInfo {
             domain_name: None,
             is_connected: false,
+            connection_error: Some("clock_skew".to_string()),
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("null"));
         assert!(json.contains("false"));
+        assert!(json.contains("clock_skew"));
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -91,6 +91,10 @@ async fn capture_snapshot(state: &AppState, object_dn: &str, operation: &str) {
 pub struct DomainInfo {
     pub domain_name: Option<String>,
     pub is_connected: bool,
+    /// Stable classification key for the last connection failure, if any.
+    /// Maps to an i18n hint on the UI. Raw error text stays in the log.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_error: Option<String>,
 }
 
 /// Paginated browse result for user listing.

--- a/src-tauri/src/services/directory.rs
+++ b/src-tauri/src/services/directory.rs
@@ -31,6 +31,17 @@ pub trait DirectoryProvider: Send + Sync {
     /// Tests the connection by performing a lightweight rootDSE query.
     async fn test_connection(&self) -> Result<bool>;
 
+    /// Returns a classification key for the last connection failure, if any.
+    ///
+    /// The value is a stable identifier (e.g. `clock_skew`, `no_credentials`,
+    /// `dns`, `ldap_signing`, `network`, `auth_denied`, `kerberos_unknown`,
+    /// `unknown`, `not_domain_joined`) that the UI maps to a localized hint.
+    /// The raw error message is not exposed here - full detail is written to
+    /// the application log at ERROR level.
+    fn last_connection_error(&self) -> Option<String> {
+        None
+    }
+
     /// Searches for user accounts matching the filter.
     async fn search_users(&self, filter: &str, max_results: usize) -> Result<Vec<DirectoryEntry>>;
 
@@ -362,6 +373,7 @@ pub mod tests {
         pub set_photo_calls: Mutex<Vec<(String, String)>>,
         pub remove_photo_calls: Mutex<Vec<String>>,
         configuration_entries: Mutex<Vec<DirectoryEntry>>,
+        connection_error: Mutex<Option<String>>,
     }
 
     impl Default for MockDirectoryProvider {
@@ -412,6 +424,7 @@ pub mod tests {
                 set_photo_calls: Mutex::new(Vec::new()),
                 remove_photo_calls: Mutex::new(Vec::new()),
                 configuration_entries: Mutex::new(Vec::new()),
+                connection_error: Mutex::new(None),
             }
         }
 
@@ -456,6 +469,7 @@ pub mod tests {
                 set_photo_calls: Mutex::new(Vec::new()),
                 remove_photo_calls: Mutex::new(Vec::new()),
                 configuration_entries: Mutex::new(Vec::new()),
+                connection_error: Mutex::new(Some("not_domain_joined".to_string())),
             }
         }
 
@@ -532,6 +546,11 @@ pub mod tests {
             self
         }
 
+        pub fn with_connection_error(self, kind: &str) -> Self {
+            *self.connection_error.lock().unwrap() = Some(kind.to_string());
+            self
+        }
+
         fn check_failure(&self) -> Result<()> {
             if *self.should_fail.lock().unwrap() {
                 anyhow::bail!("Mock directory provider failure");
@@ -561,6 +580,10 @@ pub mod tests {
         async fn test_connection(&self) -> Result<bool> {
             self.check_failure()?;
             Ok(self.is_connected())
+        }
+
+        fn last_connection_error(&self) -> Option<String> {
+            self.connection_error.lock().unwrap().clone()
         }
 
         async fn search_users(

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -353,6 +353,99 @@ pub struct LdapDirectoryProvider {
     dc_fqdn: Mutex<Option<String>>,
     /// Timestamp of the last successful LDAP operation.
     last_successful_op: Mutex<Option<std::time::Instant>>,
+    /// Stable classification key for the last connection failure (no raw text).
+    /// See `classify_bind_error` for the set of possible values.
+    last_error_kind: Mutex<Option<String>>,
+}
+
+/// Maps a bind/connect error chain to a stable classification key for the UI.
+///
+/// The raw message is not exposed to the frontend - it is written to logs at
+/// ERROR level. This function only inspects `err.to_string()` (plus the chain)
+/// and returns one of: `clock_skew`, `no_credentials`, `unknown_principal`,
+/// `ldap_signing`, `dns`, `network`, `auth_denied`, `tls`, `kerberos_unknown`,
+/// `not_domain_joined`, `unknown`.
+fn classify_bind_error(err: &anyhow::Error) -> &'static str {
+    let mut chain = String::new();
+    for cause in err.chain() {
+        chain.push_str(&cause.to_string());
+        chain.push(' ');
+    }
+    let msg = chain.to_lowercase();
+
+    if msg.contains("not domain-joined") || msg.contains("no domain available") {
+        return "not_domain_joined";
+    }
+    if msg.contains("clock skew")
+        || msg.contains("time skew")
+        || msg.contains("skew too great")
+        || msg.contains("preauth")
+        || msg.contains("krb_ap_err_skew")
+    {
+        return "clock_skew";
+    }
+    if msg.contains("no credentials")
+        || msg.contains("no cached credentials")
+        || msg.contains("no kerberos")
+        || msg.contains("no tgt")
+        || msg.contains("credentials cache")
+        || msg.contains("ccache")
+        || msg.contains("0x8009030e")
+    {
+        return "no_credentials";
+    }
+    if msg.contains("server not found in kerberos database")
+        || msg.contains("s_principal_unknown")
+        || msg.contains("unknown server")
+        || msg.contains("unknown principal")
+    {
+        return "unknown_principal";
+    }
+    if msg.contains("strong(er) auth")
+        || msg.contains("strong authentication")
+        || msg.contains("confidentiality required")
+        || msg.contains("ldap signing")
+        || msg.contains("sign and seal")
+    {
+        return "ldap_signing";
+    }
+    if msg.contains("name or service not known")
+        || msg.contains("nodename nor servname")
+        || msg.contains("no such host")
+        || msg.contains("_ldap._tcp")
+        || msg.contains("dns")
+        || msg.contains("getaddrinfo")
+    {
+        return "dns";
+    }
+    if msg.contains("connection refused")
+        || msg.contains("no route to host")
+        || msg.contains("network unreachable")
+        || msg.contains("timed out")
+        || msg.contains("timeout")
+        || msg.contains("connection reset")
+    {
+        return "network";
+    }
+    if msg.contains("tls")
+        || msg.contains("certificate")
+        || msg.contains("handshake")
+        || msg.contains("starttls")
+    {
+        return "tls";
+    }
+    if msg.contains("insufficient access")
+        || msg.contains("invalid credentials")
+        || msg.contains("access denied")
+        || msg.contains("49)")
+        || msg.contains("rc=49")
+    {
+        return "auth_denied";
+    }
+    if msg.contains("gssapi") || msg.contains("kerberos") || msg.contains("sasl") {
+        return "kerberos_unknown";
+    }
+    "unknown"
 }
 
 /// Parses the server string and returns (host, use_tls).
@@ -391,6 +484,12 @@ impl LdapDirectoryProvider {
             Some(d) => tracing::info!("Domain detected: {}", d),
         }
 
+        let initial_error = if domain.is_none() {
+            Some("not_domain_joined".to_string())
+        } else {
+            None
+        };
+
         Self {
             domain,
             server_override: None,
@@ -402,6 +501,7 @@ impl LdapDirectoryProvider {
             authenticated_user: Mutex::new(None),
             dc_fqdn: Mutex::new(None),
             last_successful_op: Mutex::new(None),
+            last_error_kind: Mutex::new(initial_error),
         }
     }
 
@@ -442,6 +542,7 @@ impl LdapDirectoryProvider {
             authenticated_user: Mutex::new(None),
             dc_fqdn: Mutex::new(None),
             last_successful_op: Mutex::new(None),
+            last_error_kind: Mutex::new(None),
         }
     }
 
@@ -697,10 +798,18 @@ impl LdapDirectoryProvider {
                     // sasl_gssapi_bind needs the server FQDN for the SPN (ldap/<fqdn>),
                     // not the domain name. Resolve DC FQDN via DNS SRV lookup.
                     let gssapi_host = resolve_dc_fqdn_for_gssapi(&host).await;
-                    tracing::debug!(gssapi_host = %gssapi_host, original_host = %host, "GSSAPI bind with resolved FQDN");
+                    let logon_server = std::env::var("LOGONSERVER").unwrap_or_default();
+                    tracing::info!(
+                        original_host = %host,
+                        gssapi_host = %gssapi_host,
+                        spn = %format!("ldap/{}", gssapi_host),
+                        logonserver = %logon_server,
+                        "GSSAPI bind attempt"
+                    );
                     ldap.sasl_gssapi_bind(&gssapi_host)
                         .await
                         .context("GSSAPI (Kerberos) authentication failed")?;
+                    tracing::info!("GSSAPI bind succeeded");
                 }
 
                 #[cfg(not(feature = "gssapi"))]
@@ -740,6 +849,7 @@ impl LdapDirectoryProvider {
         }
 
         *self.connected.lock().expect("lock poisoned") = true;
+        *self.last_error_kind.lock().expect("lock poisoned") = None;
         Ok(ldap)
     }
 
@@ -1131,16 +1241,33 @@ impl DirectoryProvider for LdapDirectoryProvider {
 
     async fn test_connection(&self) -> Result<bool> {
         if self.domain.is_none() {
+            *self.last_error_kind.lock().expect("lock poisoned") =
+                Some("not_domain_joined".to_string());
             return Ok(false);
         }
         match self.get_connection().await {
-            Ok(_) => Ok(true),
+            Ok(_) => {
+                *self.last_error_kind.lock().expect("lock poisoned") = None;
+                Ok(true)
+            }
             Err(e) => {
-                tracing::warn!("Connection test failed: {}", e);
+                let kind = classify_bind_error(&e);
+                let chain: Vec<String> = e.chain().map(|c| c.to_string()).collect();
+                tracing::error!(
+                    kind = kind,
+                    chain = ?chain,
+                    "LDAP connection test failed: {:#}",
+                    e
+                );
+                *self.last_error_kind.lock().expect("lock poisoned") = Some(kind.to_string());
                 self.invalidate_connection().await;
                 Ok(false)
             }
         }
+    }
+
+    fn last_connection_error(&self) -> Option<String> {
+        self.last_error_kind.lock().expect("lock poisoned").clone()
     }
 
     async fn search_users(&self, filter: &str, max_results: usize) -> Result<Vec<DirectoryEntry>> {
@@ -3483,11 +3610,88 @@ mod tests {
 
         let provider = LdapDirectoryProvider::new();
         assert!(!provider.test_connection().await.unwrap());
+        assert_eq!(
+            provider.last_connection_error().as_deref(),
+            Some("not_domain_joined")
+        );
 
         if let Some(val) = original {
             unsafe {
                 std::env::set_var("USERDNSDOMAIN", val);
             }
         }
+    }
+
+    #[test]
+    fn test_classify_bind_error_clock_skew() {
+        let e = anyhow::anyhow!("GSSAPI: clock skew too great");
+        assert_eq!(classify_bind_error(&e), "clock_skew");
+    }
+
+    #[test]
+    fn test_classify_bind_error_no_credentials() {
+        let e = anyhow::anyhow!("No credentials cache found (filename: FILE:/tmp/krb5cc)");
+        assert_eq!(classify_bind_error(&e), "no_credentials");
+    }
+
+    #[test]
+    fn test_classify_bind_error_unknown_principal() {
+        let e = anyhow::anyhow!("Server not found in Kerberos database");
+        assert_eq!(classify_bind_error(&e), "unknown_principal");
+    }
+
+    #[test]
+    fn test_classify_bind_error_ldap_signing() {
+        let e = anyhow::anyhow!("Server requires confidentiality required");
+        assert_eq!(classify_bind_error(&e), "ldap_signing");
+    }
+
+    #[test]
+    fn test_classify_bind_error_dns() {
+        let e = anyhow::anyhow!("getaddrinfo: Name or service not known");
+        assert_eq!(classify_bind_error(&e), "dns");
+    }
+
+    #[test]
+    fn test_classify_bind_error_network() {
+        let e = anyhow::anyhow!("Connection refused (os error 111)");
+        assert_eq!(classify_bind_error(&e), "network");
+    }
+
+    #[test]
+    fn test_classify_bind_error_tls() {
+        let e = anyhow::anyhow!("TLS handshake failure: bad certificate");
+        assert_eq!(classify_bind_error(&e), "tls");
+    }
+
+    #[test]
+    fn test_classify_bind_error_auth_denied() {
+        let e = anyhow::anyhow!("Simple bind failed (rc=49): invalid credentials");
+        assert_eq!(classify_bind_error(&e), "auth_denied");
+    }
+
+    #[test]
+    fn test_classify_bind_error_kerberos_fallback() {
+        let e = anyhow::anyhow!("GSSAPI returned an unrecognized minor code");
+        assert_eq!(classify_bind_error(&e), "kerberos_unknown");
+    }
+
+    #[test]
+    fn test_classify_bind_error_unknown() {
+        let e = anyhow::anyhow!("Something completely unexpected happened");
+        assert_eq!(classify_bind_error(&e), "unknown");
+    }
+
+    #[test]
+    fn test_classify_bind_error_not_domain_joined() {
+        let e = anyhow::anyhow!("No domain available - machine is not domain-joined");
+        assert_eq!(classify_bind_error(&e), "not_domain_joined");
+    }
+
+    #[test]
+    fn test_classify_bind_error_follows_cause_chain() {
+        let root = anyhow::anyhow!("getaddrinfo EAI_NONAME");
+        let wrapped: anyhow::Error = root.context("resolving _ldap._tcp.corp.local");
+        assert_eq!(classify_bind_error(&wrapped), "dns");
     }
 }

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -1977,7 +1977,7 @@ impl DirectoryProvider for LdapDirectoryProvider {
                     })
                     .collect();
 
-                flat_ous.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+                flat_ous.sort_by_key(|a| a.1.to_lowercase());
                 Ok(build_ou_tree(&flat_ous, &base))
             }
         })
@@ -3262,7 +3262,7 @@ fn build_ou_tree(flat_ous: &[(String, String)], base_dn: &str) -> Vec<OUNode> {
             })
             .collect();
 
-        nodes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        nodes.sort_by_key(|a| a.name.to_lowercase());
         nodes
     }
 

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -358,6 +358,26 @@ pub struct LdapDirectoryProvider {
     last_error_kind: Mutex<Option<String>>,
 }
 
+/// Strips common Latin-1/Latin-2 accents so multilingual keyword matching
+/// works against error texts produced by Windows `FormatMessageW` in French,
+/// German, Italian, Spanish, etc. Cheap pass - does not normalize ligatures
+/// or combining characters, which none of our target strings use.
+fn fold_ascii(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'á' | 'à' | 'â' | 'ä' | 'ã' | 'å' => 'a',
+            'ç' => 'c',
+            'é' | 'è' | 'ê' | 'ë' => 'e',
+            'í' | 'ì' | 'î' | 'ï' => 'i',
+            'ñ' => 'n',
+            'ó' | 'ò' | 'ô' | 'ö' | 'õ' => 'o',
+            'ú' | 'ù' | 'û' | 'ü' => 'u',
+            'ý' | 'ÿ' => 'y',
+            _ => c,
+        })
+        .collect()
+}
+
 /// Maps a bind/connect error chain to a stable classification key for the UI.
 ///
 /// The raw message is not exposed to the frontend - it is written to logs at
@@ -365,47 +385,110 @@ pub struct LdapDirectoryProvider {
 /// and returns one of: `clock_skew`, `no_credentials`, `unknown_principal`,
 /// `ldap_signing`, `dns`, `network`, `auth_denied`, `tls`, `kerberos_unknown`,
 /// `not_domain_joined`, `unknown`.
+///
+/// On Windows, `cross-krb5` formats SSPI errors with `FormatMessageW` using
+/// `LANG_NEUTRAL`, so the text is localized in the OS UI language. The matches
+/// below cover English plus the Microsoft-localized strings for French,
+/// German, Italian and Spanish - confirmed via Microsoft Learn, public
+/// bug trackers (dotnet/runtime #27493, #45680) and the `finderr.net`
+/// translation index. Keywords are chosen to be the stable terminology
+/// fragments rather than the full sentence, so minor wording revisions
+/// in a Windows service pack do not break classification.
 fn classify_bind_error(err: &anyhow::Error) -> &'static str {
     let mut chain = String::new();
     for cause in err.chain() {
         chain.push_str(&cause.to_string());
         chain.push(' ');
     }
-    let msg = chain.to_lowercase();
+    // Lowercase then accent-fold so keyword patterns written in ASCII match
+    // localized Windows SSPI messages (see `fold_ascii`).
+    let msg = fold_ascii(&chain.to_lowercase());
 
     if msg.contains("not domain-joined") || msg.contains("no domain available") {
         return "not_domain_joined";
     }
+    // SEC_E_TIME_SKEW / KRB_AP_ERR_SKEW
+    //   EN: "The clocks on the client and server machines are skewed"
+    //   FR: "les horloges ... sont decalees"
+    //   DE: "Uhren ... weichen ab" / "Zeitabweichung"
+    //   IT: "orologi ... disallineati" / "scostamento"
+    //   ES: "relojes ... desfasados" / "desfase"
     if msg.contains("clock skew")
         || msg.contains("time skew")
         || msg.contains("skew too great")
         || msg.contains("preauth")
         || msg.contains("krb_ap_err_skew")
+        || msg.contains("horloge")
+        || msg.contains("uhren")
+        || msg.contains("uhr ")
+        || msg.contains("zeitabweich")
+        || msg.contains("orologi")
+        || msg.contains("disallin")
+        || msg.contains("scostament")
+        || msg.contains("reloj")
+        || msg.contains("desfas")
+        || msg.contains("desincron")
     {
         return "clock_skew";
     }
+    // SEC_E_NO_CREDENTIALS (0x8009030E): "No credentials are available in the
+    // security package"
+    //   FR: "Aucune information d'identification n'est disponible dans le
+    //        package de securite"
+    //   DE: "Im Sicherheitspaket sind keine Anmeldeinformationen verfuegbar"
+    //   IT: "Nessuna credenziale disponibile nel pacchetto di sicurezza"
+    //   ES: "No hay credenciales disponibles en el paquete de seguridad"
     if msg.contains("no credentials")
         || msg.contains("no cached credentials")
         || msg.contains("no kerberos")
         || msg.contains("no tgt")
         || msg.contains("credentials cache")
         || msg.contains("ccache")
-        || msg.contains("0x8009030e")
+        || msg.contains("information d'identification")
+        || msg.contains("anmeldeinformationen")
+        || msg.contains("sicherheitspaket")
+        || msg.contains("nessuna credenziale")
+        || msg.contains("pacchetto di sicurezza")
+        || msg.contains("no hay credenciales")
+        || msg.contains("paquete de seguridad")
     {
         return "no_credentials";
     }
+    // SEC_E_WRONG_PRINCIPAL / SEC_E_TARGET_UNKNOWN:
+    //   EN: "target principal name is incorrect" / "target is unknown"
+    //   FR: "nom principal de la cible ... incorrect" / "cible ... inconnue"
+    //   DE: "Zielprinzipalname ... falsch" / "Ziel ... unbekannt"
+    //   IT: "nome principale di destinazione non e corretto" /
+    //        "destinazione ... sconosciuta"
+    //   ES: "nombre de principal de destino ... incorrecto" /
+    //        "destino ... desconocido"
     if msg.contains("server not found in kerberos database")
         || msg.contains("s_principal_unknown")
         || msg.contains("unknown server")
         || msg.contains("unknown principal")
+        || msg.contains("target principal")
+        || msg.contains("target is unknown")
+        || msg.contains("principal de la cible")
+        || msg.contains("cible specifiee")
+        || msg.contains("zielprinzipal")
+        || msg.contains("ziel ist unbekannt")
+        || msg.contains("principale di destinazione")
+        || msg.contains("destinazione specificata")
+        || msg.contains("principal de destino")
+        || msg.contains("destino especificado")
     {
         return "unknown_principal";
     }
+    // LDAP signing / sealing required by the DC
     if msg.contains("strong(er) auth")
         || msg.contains("strong authentication")
         || msg.contains("confidentiality required")
         || msg.contains("ldap signing")
         || msg.contains("sign and seal")
+        || msg.contains("authentification plus forte")
+        || msg.contains("starkere authentifizierung")
+        || msg.contains("autenticazione piu forte")
+        || msg.contains("autenticacion mas segura")
     {
         return "ldap_signing";
     }
@@ -431,14 +514,37 @@ fn classify_bind_error(err: &anyhow::Error) -> &'static str {
         || msg.contains("certificate")
         || msg.contains("handshake")
         || msg.contains("starttls")
+        || msg.contains("certificat")
+        || msg.contains("zertifikat")
+        || msg.contains("certificato")
+        || msg.contains("certificado")
     {
         return "tls";
     }
+    // SEC_E_LOGON_DENIED (0x8009030C) / LDAP invalidCredentials (rc=49)
+    //   EN: "logon attempt failed" / "invalid credentials" / "access denied"
+    //   FR: "ouverture de session ... echoue" / "identifiants ... invalides" /
+    //        "acces refuse"
+    //   DE: "Anmeld... fehlgeschlagen" / "Zugriff verweigert"
+    //   IT: "accesso ... non riuscito" / "accesso negato" /
+    //        "credenziali non valide"
+    //   ES: "inicio de sesion ... fallido" / "acceso denegado" /
+    //        "credenciales no validas"
     if msg.contains("insufficient access")
         || msg.contains("invalid credentials")
         || msg.contains("access denied")
         || msg.contains("49)")
         || msg.contains("rc=49")
+        || msg.contains("ouverture de session")
+        || msg.contains("identifiants invalides")
+        || msg.contains("acces refuse")
+        || msg.contains("anmeld")
+        || msg.contains("zugriff verweigert")
+        || msg.contains("accesso negato")
+        || msg.contains("credenziali non valide")
+        || msg.contains("inicio de sesion")
+        || msg.contains("acceso denegado")
+        || msg.contains("credenciales no validas")
     {
         return "auth_denied";
     }
@@ -3693,5 +3799,90 @@ mod tests {
         let root = anyhow::anyhow!("getaddrinfo EAI_NONAME");
         let wrapped: anyhow::Error = root.context("resolving _ldap._tcp.corp.local");
         assert_eq!(classify_bind_error(&wrapped), "dns");
+    }
+
+    // Windows SSPI error text is localized in the OS UI language via
+    // FormatMessageW(LANG_NEUTRAL). The tests below exercise the known
+    // Microsoft translations we match against (FR/DE/IT/ES).
+
+    #[test]
+    fn test_classify_bind_error_no_credentials_fr() {
+        let e = anyhow::anyhow!(
+            "GSSAPI operation error: ClientCtx::step failed Aucune information d'identification n'est disponible dans le package de sécurité"
+        );
+        assert_eq!(classify_bind_error(&e), "no_credentials");
+    }
+
+    #[test]
+    fn test_classify_bind_error_no_credentials_de() {
+        let e = anyhow::anyhow!("Im Sicherheitspaket sind keine Anmeldeinformationen verfügbar");
+        assert_eq!(classify_bind_error(&e), "no_credentials");
+    }
+
+    #[test]
+    fn test_classify_bind_error_no_credentials_it() {
+        let e = anyhow::anyhow!("Nessuna credenziale disponibile nel pacchetto di sicurezza");
+        assert_eq!(classify_bind_error(&e), "no_credentials");
+    }
+
+    #[test]
+    fn test_classify_bind_error_no_credentials_es() {
+        let e = anyhow::anyhow!("No hay credenciales disponibles en el paquete de seguridad");
+        assert_eq!(classify_bind_error(&e), "no_credentials");
+    }
+
+    #[test]
+    fn test_classify_bind_error_unknown_principal_fr() {
+        let e = anyhow::anyhow!("Le nom principal de la cible n'est pas correct");
+        assert_eq!(classify_bind_error(&e), "unknown_principal");
+    }
+
+    #[test]
+    fn test_classify_bind_error_unknown_principal_de() {
+        let e = anyhow::anyhow!("Der Zielprinzipalname ist falsch");
+        assert_eq!(classify_bind_error(&e), "unknown_principal");
+    }
+
+    #[test]
+    fn test_classify_bind_error_clock_skew_fr() {
+        let e = anyhow::anyhow!("Les horloges des ordinateurs client et serveur sont décalées");
+        assert_eq!(classify_bind_error(&e), "clock_skew");
+    }
+
+    #[test]
+    fn test_classify_bind_error_clock_skew_de() {
+        let e = anyhow::anyhow!("Zeitabweichung zwischen Client und Server");
+        assert_eq!(classify_bind_error(&e), "clock_skew");
+    }
+
+    #[test]
+    fn test_classify_bind_error_auth_denied_fr() {
+        let e = anyhow::anyhow!("La tentative d'ouverture de session a échoué");
+        assert_eq!(classify_bind_error(&e), "auth_denied");
+    }
+
+    #[test]
+    fn test_classify_bind_error_auth_denied_de() {
+        let e = anyhow::anyhow!("Anmeldeversuch fehlgeschlagen - Zugriff verweigert");
+        assert_eq!(classify_bind_error(&e), "auth_denied");
+    }
+
+    #[test]
+    fn test_classify_bind_error_auth_denied_es() {
+        let e = anyhow::anyhow!("Credenciales no válidas - acceso denegado");
+        assert_eq!(classify_bind_error(&e), "auth_denied");
+    }
+
+    #[test]
+    fn test_fold_ascii_strips_accents() {
+        assert_eq!(fold_ascii("décalées"), "decalees");
+        assert_eq!(fold_ascii("sécurité"), "securite");
+        assert_eq!(fold_ascii("échoué"), "echoue");
+        assert_eq!(fold_ascii("verfügbar"), "verfugbar");
+        assert_eq!(fold_ascii("stärkere"), "starkere");
+        assert_eq!(fold_ascii("più"), "piu");
+        assert_eq!(fold_ascii("sesión"), "sesion");
+        assert_eq!(fold_ascii("válidas"), "validas");
+        assert_eq!(fold_ascii("año"), "ano");
     }
 }

--- a/src-tauri/src/services/preset.rs
+++ b/src-tauri/src/services/preset.rs
@@ -282,7 +282,7 @@ impl PresetService {
             }
         }
 
-        presets.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        presets.sort_by_key(|a| a.name.to_lowercase());
         presets
     }
 

--- a/src-tauri/src/services/replication.rs
+++ b/src-tauri/src/services/replication.rs
@@ -93,18 +93,16 @@ pub fn parse_replication_metadata(raw_xml: &str) -> Vec<AttributeMetadata> {
                     current_tag = tag;
                 }
             }
-            Ok(Event::Text(e)) => {
-                if in_entry && !current_tag.is_empty() {
-                    let text = String::from_utf8_lossy(&e).trim().to_string();
-                    match current_tag.as_str() {
-                        "pszAttributeName" => attr_name = text,
-                        "dwVersion" => version = text.parse().unwrap_or(0),
-                        "ftimeLastOriginatingChange" => change_time = text,
-                        "pszLastOriginatingDsaDN" => dsa_dn = text,
-                        "usnLocalChange" => local_usn = text.parse().unwrap_or(0),
-                        "usnOriginatingChange" => originating_usn = text.parse().unwrap_or(0),
-                        _ => {}
-                    }
+            Ok(Event::Text(e)) if in_entry && !current_tag.is_empty() => {
+                let text = String::from_utf8_lossy(&e).trim().to_string();
+                match current_tag.as_str() {
+                    "pszAttributeName" => attr_name = text,
+                    "dwVersion" => version = text.parse().unwrap_or(0),
+                    "ftimeLastOriginatingChange" => change_time = text,
+                    "pszLastOriginatingDsaDN" => dsa_dn = text,
+                    "usnLocalChange" => local_usn = text.parse().unwrap_or(0),
+                    "usnOriginatingChange" => originating_usn = text.parse().unwrap_or(0),
+                    _ => {}
                 }
             }
             Ok(Event::End(e)) => {
@@ -182,22 +180,20 @@ pub fn parse_replication_value_metadata(raw_xml: &str) -> Vec<ValueMetadata> {
                     current_tag = tag;
                 }
             }
-            Ok(Event::Text(e)) => {
-                if in_entry && !current_tag.is_empty() {
-                    let text = String::from_utf8_lossy(&e).trim().to_string();
-                    match current_tag.as_str() {
-                        "pszAttributeName" => attr_name = text,
-                        "pszObjectDn" => object_dn = text,
-                        "dwVersion" => version = text.parse().unwrap_or(0),
-                        "ftimeLastOriginatingChange" => change_time = text,
-                        "pszLastOriginatingDsaDN" => dsa_dn = text,
-                        "usnLocalChange" => local_usn = text.parse().unwrap_or(0),
-                        "usnOriginatingChange" => originating_usn = text.parse().unwrap_or(0),
-                        "ftimeDeleted" => {
-                            is_deleted = !text.is_empty() && text != "1601-01-01T00:00:00Z"
-                        }
-                        _ => {}
+            Ok(Event::Text(e)) if in_entry && !current_tag.is_empty() => {
+                let text = String::from_utf8_lossy(&e).trim().to_string();
+                match current_tag.as_str() {
+                    "pszAttributeName" => attr_name = text,
+                    "pszObjectDn" => object_dn = text,
+                    "dwVersion" => version = text.parse().unwrap_or(0),
+                    "ftimeLastOriginatingChange" => change_time = text,
+                    "pszLastOriginatingDsaDN" => dsa_dn = text,
+                    "usnLocalChange" => local_usn = text.parse().unwrap_or(0),
+                    "usnOriginatingChange" => originating_usn = text.parse().unwrap_or(0),
+                    "ftimeDeleted" => {
+                        is_deleted = !text.is_empty() && text != "1601-01-01T00:00:00Z"
                     }
+                    _ => {}
                 }
             }
             Ok(Event::End(e)) => {

--- a/src-tauri/src/services/replication_status.rs
+++ b/src-tauri/src/services/replication_status.rs
@@ -397,15 +397,11 @@ fn parse_single_repl_neighbor_xml(xml: &str) -> Option<ReplNeighborXml> {
                     "dwReplicaFlags" => {
                         neighbor.replica_flags = text.parse().unwrap_or(0);
                     }
-                    "ftimeLastSyncSuccess" => {
-                        if !text.is_empty() && text != "0" {
-                            neighbor.last_sync_success = Some(text);
-                        }
+                    "ftimeLastSyncSuccess" if !text.is_empty() && text != "0" => {
+                        neighbor.last_sync_success = Some(text);
                     }
-                    "ftimeLastSyncAttempt" => {
-                        if !text.is_empty() && text != "0" {
-                            neighbor.last_sync_attempt = Some(text);
-                        }
+                    "ftimeLastSyncAttempt" if !text.is_empty() && text != "0" => {
+                        neighbor.last_sync_attempt = Some(text);
                     }
                     "dwLastSyncResult" => {
                         neighbor.last_sync_result = text.parse().unwrap_or(0);

--- a/src-tauri/src/services/resilient_directory.rs
+++ b/src-tauri/src/services/resilient_directory.rs
@@ -162,6 +162,10 @@ where
         resilient_call!(self, |inner| inner.test_connection().await)
     }
 
+    fn last_connection_error(&self) -> Option<String> {
+        self.inner.last_connection_error()
+    }
+
     async fn search_users(&self, filter: &str, max_results: usize) -> Result<Vec<DirectoryEntry>> {
         let filter = filter.to_string();
         resilient_call!(self, filter, |inner, f| inner

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSPanel",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.rwx-g.dspanel",
   "build": {
     "beforeDevCommand": "npx pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,11 +54,13 @@ function installGlobalErrorHandlers() {
 interface DomainInfo {
   domain_name: string | null;
   is_connected: boolean;
+  connection_error?: string | null;
 }
 
 export interface AppStatus {
   isConnected: boolean;
   domainName: string | null;
+  connectionError: string | null;
   permissionLevel: string;
   authenticatedUser: string;
   username: string;
@@ -75,6 +77,7 @@ export function App() {
   const [status, setStatus] = useState<AppStatus>({
     isConnected: false,
     domainName: null,
+    connectionError: null,
     permissionLevel: "ReadOnly",
     authenticatedUser: "",
     username: "",
@@ -93,6 +96,7 @@ export function App() {
           ...s,
           domainName: info.domain_name,
           isConnected: info.is_connected,
+          connectionError: info.connection_error ?? null,
         }));
       })
       .catch((e) => console.warn("Failed to get domain info:", e));
@@ -100,6 +104,16 @@ export function App() {
     invoke<boolean>("check_connection")
       .then((connected) => {
         setStatus((s) => ({ ...s, isConnected: connected }));
+        // Refresh the error kind after check_connection, which may have just
+        // updated the provider's last_error_kind.
+        invoke<DomainInfo>("get_domain_info")
+          .then((info) =>
+            setStatus((s) => ({
+              ...s,
+              connectionError: info.connection_error ?? null,
+            })),
+          )
+          .catch(() => {});
       })
       .catch((e) => console.warn("Failed to check connection:", e));
 

--- a/src/locales/de/home.json
+++ b/src/locales/de/home.json
@@ -19,5 +19,19 @@
   "helpDesk": "HelpDesk",
   "accountOperator": "Kontobediener",
   "admin": "Admin",
-  "domainAdmin": "Domänen-Admin"
+  "domainAdmin": "Domänen-Admin",
+  "kerberosHint": {
+    "logRef": "Vollständige technische Fehlermeldung siehe Anwendungsprotokoll.",
+    "not_domain_joined": "Dieser Arbeitsplatz ist keiner Active-Directory-Domäne beigetreten.",
+    "clock_skew": "Die Uhr des Arbeitsplatzes ist nicht mit dem Domain Controller synchron (mehr als 5 Minuten Abweichung).",
+    "no_credentials": "Kein Kerberos-Ticket verfügbar. Melden Sie sich ab und wieder an oder führen Sie `klist purge` und anschließend `kinit` aus.",
+    "unknown_principal": "Der LDAP-SPN ist Kerberos unbekannt. Der DC-Hostname wird möglicherweise falsch aufgelöst.",
+    "ldap_signing": "Der Domain Controller verlangt LDAP-Signierung oder -Versiegelung, die der aktuelle Bind nicht liefern kann.",
+    "dns": "DNS-Auflösung fehlgeschlagen. Der SRV-Eintrag `_ldap._tcp.<Domäne>` konnte nicht aufgelöst werden.",
+    "network": "Netzwerkverbindung zum Domain Controller fehlgeschlagen (abgelehnt, nicht erreichbar oder Zeitüberschreitung).",
+    "tls": "TLS-Handshake mit dem Domain Controller fehlgeschlagen. Prüfen Sie Zertifikatsvertrauen und Port 636.",
+    "auth_denied": "Authentifizierung vom Verzeichnis abgelehnt (ungültige Anmeldeinformationen oder unzureichende Rechte).",
+    "kerberos_unknown": "Kerberos-Authentifizierung aus einem nicht erkannten Grund fehlgeschlagen.",
+    "unknown": "Verbindung aus unbekanntem Grund fehlgeschlagen."
+  }
 }

--- a/src/locales/en/home.json
+++ b/src/locales/en/home.json
@@ -19,5 +19,19 @@
   "helpDesk": "Help Desk",
   "accountOperator": "Account Operator",
   "admin": "Admin",
-  "domainAdmin": "Domain Admin"
+  "domainAdmin": "Domain Admin",
+  "kerberosHint": {
+    "logRef": "See the application log for the full technical error.",
+    "not_domain_joined": "This workstation is not joined to an Active Directory domain.",
+    "clock_skew": "Workstation clock is out of sync with the domain controller (more than 5 minutes).",
+    "no_credentials": "No Kerberos ticket available. Sign out and back in, or run `klist purge` then `kinit`.",
+    "unknown_principal": "The LDAP service principal name (SPN) is unknown to Kerberos. DC hostname may be misresolved.",
+    "ldap_signing": "The domain controller requires LDAP signing or sealing that the current bind cannot provide.",
+    "dns": "DNS resolution failed. The `_ldap._tcp.<domain>` SRV record could not be resolved.",
+    "network": "Network connection to the domain controller failed (refused, unreachable, or timed out).",
+    "tls": "TLS handshake with the domain controller failed. Check certificate trust and port 636.",
+    "auth_denied": "Authentication was rejected by the directory (invalid credentials or insufficient access).",
+    "kerberos_unknown": "Kerberos authentication failed for an unrecognized reason.",
+    "unknown": "Connection failed for an unknown reason."
+  }
 }

--- a/src/locales/es/home.json
+++ b/src/locales/es/home.json
@@ -19,5 +19,19 @@
   "helpDesk": "Mesa de ayuda",
   "accountOperator": "Operador de cuentas",
   "admin": "Admin",
-  "domainAdmin": "Administrador de dominio"
+  "domainAdmin": "Administrador de dominio",
+  "kerberosHint": {
+    "logRef": "Consulte el registro de la aplicación para ver el error técnico completo.",
+    "not_domain_joined": "Esta estación de trabajo no está unida a un dominio de Active Directory.",
+    "clock_skew": "El reloj de la estación está desincronizado con el Domain Controller (más de 5 minutos).",
+    "no_credentials": "No hay ticket Kerberos disponible. Cierre y vuelva a abrir la sesión, o ejecute `klist purge` y luego `kinit`.",
+    "unknown_principal": "El SPN LDAP es desconocido para Kerberos. El nombre de host del DC puede resolverse incorrectamente.",
+    "ldap_signing": "El Domain Controller requiere firma o sellado LDAP que el bind actual no puede proporcionar.",
+    "dns": "Falló la resolución DNS. No se pudo resolver el registro SRV `_ldap._tcp.<dominio>`.",
+    "network": "La conexión de red con el Domain Controller falló (rechazada, inalcanzable o caducada).",
+    "tls": "Falló la negociación TLS con el Domain Controller. Verifique la confianza del certificado y el puerto 636.",
+    "auth_denied": "Autenticación rechazada por el directorio (credenciales no válidas o acceso insuficiente).",
+    "kerberos_unknown": "La autenticación Kerberos falló por un motivo no reconocido.",
+    "unknown": "La conexión falló por un motivo desconocido."
+  }
 }

--- a/src/locales/fr/home.json
+++ b/src/locales/fr/home.json
@@ -19,5 +19,19 @@
   "helpDesk": "Help Desk",
   "accountOperator": "Opérateur de comptes",
   "admin": "Admin",
-  "domainAdmin": "Administrateur du domaine"
+  "domainAdmin": "Administrateur du domaine",
+  "kerberosHint": {
+    "logRef": "Consultez le journal de l'application pour l'erreur technique complète.",
+    "not_domain_joined": "Ce poste n'est pas joint à un domaine Active Directory.",
+    "clock_skew": "L'horloge du poste est désynchronisée avec le Domain Controller (plus de 5 minutes).",
+    "no_credentials": "Aucun ticket Kerberos disponible. Déconnectez-vous puis reconnectez la session, ou exécutez `klist purge` puis `kinit`.",
+    "unknown_principal": "Le SPN LDAP est inconnu de Kerberos. Le nom d'hôte du DC est peut-être mal résolu.",
+    "ldap_signing": "Le Domain Controller exige une signature ou un scellement LDAP que le bind actuel ne peut pas fournir.",
+    "dns": "Échec de la résolution DNS. L'enregistrement SRV `_ldap._tcp.<domaine>` n'a pas pu être résolu.",
+    "network": "La connexion réseau vers le Domain Controller a échoué (refusée, injoignable ou expirée).",
+    "tls": "Échec de la négociation TLS avec le Domain Controller. Vérifiez la confiance du certificat et le port 636.",
+    "auth_denied": "Authentification rejetée par l'annuaire (identifiants invalides ou accès insuffisant).",
+    "kerberos_unknown": "L'authentification Kerberos a échoué pour une raison non reconnue.",
+    "unknown": "La connexion a échoué pour une raison inconnue."
+  }
 }

--- a/src/locales/it/home.json
+++ b/src/locales/it/home.json
@@ -19,5 +19,19 @@
   "helpDesk": "Help Desk",
   "accountOperator": "Operatore account",
   "admin": "Amministratore",
-  "domainAdmin": "Amministratore di dominio"
+  "domainAdmin": "Amministratore di dominio",
+  "kerberosHint": {
+    "logRef": "Consulta il registro dell'applicazione per l'errore tecnico completo.",
+    "not_domain_joined": "Questa postazione non è aggiunta a un dominio Active Directory.",
+    "clock_skew": "L'orologio della postazione non è sincronizzato con il Domain Controller (più di 5 minuti).",
+    "no_credentials": "Nessun ticket Kerberos disponibile. Disconnetti e riaccedi, oppure esegui `klist purge` e poi `kinit`.",
+    "unknown_principal": "L'SPN LDAP è sconosciuto a Kerberos. Il nome host del DC potrebbe essere risolto in modo errato.",
+    "ldap_signing": "Il Domain Controller richiede la firma o il sigillo LDAP che il bind attuale non può fornire.",
+    "dns": "Risoluzione DNS non riuscita. Il record SRV `_ldap._tcp.<dominio>` non è stato risolto.",
+    "network": "La connessione di rete al Domain Controller non è riuscita (rifiutata, irraggiungibile o scaduta).",
+    "tls": "Handshake TLS con il Domain Controller non riuscito. Verifica la fiducia del certificato e la porta 636.",
+    "auth_denied": "Autenticazione rifiutata dalla directory (credenziali non valide o accesso insufficiente).",
+    "kerberos_unknown": "L'autenticazione Kerberos non è riuscita per un motivo non riconosciuto.",
+    "unknown": "La connessione non è riuscita per un motivo sconosciuto."
+  }
 }

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -37,6 +37,7 @@ function makeStatus(overrides: Partial<AppStatus> = {}): AppStatus {
   return {
     isConnected: true,
     domainName: "example.com",
+    connectionError: null,
     permissionLevel: "HelpDesk",
     authenticatedUser: "jdoe@example.com",
     username: "jdoe",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -229,6 +229,18 @@ export function HomePage({ status }: HomePageProps) {
             <p className="text-caption text-[var(--color-warning)]">
               {t("notConnectedWarning")}
             </p>
+            {status.connectionError && (
+              <>
+                <p className="mt-2 text-caption font-medium text-[var(--color-warning)]">
+                  {t(`kerberosHint.${status.connectionError}`, {
+                    defaultValue: t("kerberosHint.unknown"),
+                  })}
+                </p>
+                <p className="mt-1 text-caption text-[var(--color-text-secondary)]">
+                  {t("kerberosHint.logRef")}
+                </p>
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
# Surface Kerberos / LDAP bind failures on the dashboard

## Summary

On a domain-joined workstation signed in as a domain user, the `Active Directory` card on the dashboard would show `Disconnected` with no actionable detail whenever `sasl_gssapi_bind` failed. The raw error was swallowed by `test_connection` and converted to a plain boolean, so operators had no way to tell whether the problem was a missing Kerberos ticket, a clock skew, a DNS SRV lookup failure, a DC that requires LDAP signing, a TLS handshake issue, or a network outage.

This PR makes the cause of every disconnection observable in two places:

- **UI (no raw text):** the disconnected card now renders a short localized hint tied to a stable classification key (`clock_skew`, `no_credentials`, `unknown_principal`, `ldap_signing`, `dns`, `network`, `tls`, `auth_denied`, `kerberos_unknown`, `not_domain_joined`). The five translation files are updated.
- **Log (full detail):** the full `anyhow::Error` chain is emitted at `ERROR` level, and GSSAPI bind diagnostics (resolved DC FQDN, computed `ldap/<fqdn>` SPN, `LOGONSERVER`) are promoted from `DEBUG` to `INFO` so they show up in the default application log without having to toggle `RUST_LOG=debug`.

### Classification goes cross-language

`cross-krb5` on Windows wraps SSPI errors with `FormatMessageW(LANG_NEUTRAL)`, which returns text in the OS UI language. An English-only keyword regex would fall through to `kerberos_unknown` on French / German / Italian / Spanish workstations, defeating the purpose of the classifier in precisely the environments where this change is most useful. `classify_bind_error` now carries keyword patterns for the five languages, and an `fold_ascii` helper strips Latin accents before matching so ASCII patterns hit accented text (`décalées`, `sécurité`, `stärkere`, `più`, `sesión`, ...).

Translations were cross-checked against Microsoft Learn docs, `dotnet/runtime` issues #27493 and #45680, public community forum pastes of localized Windows error messages, and the `finderr.net` Windows error index. Only translation fragments that are stable Microsoft terminology (e.g. `Anmeldeinformationen`, `information d'identification`, `Zielprinzipal`, `credenziali non valide`) are matched, so a minor wording revision in a future service pack will not silently break classification.

### Drive-by fixes

- `fix(clippy)`: Rust 1.95 promoted `clippy::unnecessary_sort_by` and `clippy::collapsible_match` from warning to error under `-D warnings`, which broke CI on code that 1.94 accepted. Bundled here because the local `act`-based pre-push hook refused the push otherwise. The refactors are semantically equivalent.
- `fix(test)`: `evaluate_health_cmd_healthy_user` and `_disabled_user` hard-coded March 2026 timestamps and flipped to `Warning` once the real clock passed the `Inactive30Days` threshold. Replaced with `days_ago_iso(n)` so the suite stays stable regardless of when it runs.
- `chore`: bumped to `1.0.3`.

## What this PR does NOT do

- It does not *fix* Kerberos failures - it makes them observable. Once the hint/log tells you the cause, you still run `w32tm /resync`, `klist purge` + re-login, fix DNS, etc.
- It does not add a periodic reconnect poll. If the connection recovers, the user still has to reload the page (unchanged from today).
- It does not wire a pre-flight SSPI check for TGT presence. That would make `no_credentials` detection truly language-independent via numeric HRESULT, but needs enabling `Win32_Security_Authentication_Identity` on the existing `windows` crate and some unsafe code - deferred unless the text-based approach turns out to miss cases in the field.

## Test plan

Automated (all green locally, matches CI pipeline):

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 1558 lib + 45 integration + 0 doc, 0 failed
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test` — 2089 passed
- [x] New tests: 24 covering classification (12 categories × English + FR/DE/IT/ES for the 4 most common), 1 covering accent folding, 1 covering error kind exposure via `get_domain_info_inner`.

Manual, to be performed in the target environment before closing the PR:

- [ ] On a domain-joined Windows 11 workstation signed in as a read-only domain user, launch DSPanel. Confirm the `Active Directory` card shows `Disconnected` with a localized hint matching the real failure cause in the log.
- [ ] Copy the `ERROR` log line and the hint. Verify the hint category lines up with what the raw error describes.
- [ ] Trigger a DNS failure by temporarily removing the DC from the host's resolver, confirm the `dns` hint fires.
- [ ] If reachable, skew the workstation clock by >5 minutes and confirm the `clock_skew` hint fires on French Windows specifically (validates the multilingual classifier).
