### PR TITLE
Fix/kerberos spn and log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-04-24
+
+### Fixed
+
+- GSSAPI bind would fail with `SEC_E_TARGET_UNKNOWN` (`unknown_principal`) on AD domains with three or more DNS labels (e.g. `INFORMADIS.LECLERC.DMI`). `resolve_dc_fqdn_for_gssapi` previously short-circuited the DNS SRV lookup whenever `host` had more than two dots, treating multi-level domain names as if they were already DC FQDNs. The check is removed; `_ldap._tcp.<host>` is now always queried first, with the existing `LOGONSERVER`-based fallback retained for environments where SRV is blocked. The fallback path is extracted into a pure helper so it can be unit-tested.
+- Application logs were being written to whatever directory the app happened to be launched from (commonly `Downloads/` after install, since Windows shortcuts inherit the launcher's working directory). `init_logging` now resolves an OS-standard absolute path via `default_log_dir()` - `%LOCALAPPDATA%\DSPanel\logs` on Windows, `~/Library/Logs/DSPanel` on macOS, `$XDG_STATE_HOME/DSPanel/logs` (or `~/.local/state/DSPanel/logs`) on Linux - and prints the resolved path to stderr at startup.
+
 ## [1.0.3] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/Rust-2024-orange.svg" alt="Rust">
   <img src="https://img.shields.io/badge/Tauri-v2-blue.svg" alt="Tauri">
   <img src="https://img.shields.io/badge/Platform-Windows%20|%20macOS%20|%20Linux-0078D6.svg" alt="Platform">
-  <img src="https://img.shields.io/badge/Status-v1.0.3-brightgreen.svg" alt="Status">
+  <img src="https://img.shields.io/badge/Status-v1.0.4-brightgreen.svg" alt="Status">
   <img src="https://img.shields.io/badge/Coverage-82%25_Rust_|_87%25_TS-brightgreen.svg" alt="Coverage">
   <img src="https://img.shields.io/badge/i18n-EN%20|%20FR%20|%20DE%20|%20ES%20|%20IT-blueviolet.svg" alt="i18n">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dspanel",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "packageManager": "pnpm@10.28.1",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dspanel"
-version = "1.0.3"
+version = "1.0.4"
 description = "DSPanel - Active Directory management tool"
 authors = ["Rwx-G"]
 license = "Apache-2.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,7 +48,7 @@ pub fn install_panic_hook() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    logging::init_logging("logs");
+    logging::init_logging(logging::default_log_dir());
     install_panic_hook();
 
     tracing::info!("DSPanel starting up");

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,16 +1,86 @@
+use std::path::{Path, PathBuf};
 use tracing_appender::rolling;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+/// Returns the OS-standard directory where DSPanel logs should be written.
+///
+/// This is computed before `init_logging` runs, so it cannot rely on the
+/// Tauri path resolver (which is only available inside the `setup` hook).
+/// Resolution per platform:
+/// - **Windows**: `%LOCALAPPDATA%\DSPanel\logs`
+/// - **macOS**: `$HOME/Library/Logs/DSPanel`
+/// - **Linux/BSD**: `$XDG_STATE_HOME/DSPanel/logs`, else `$HOME/.local/state/DSPanel/logs`
+///
+/// Falls back to a relative `logs/` path if no environment variable is
+/// available (typically only in stripped CI environments). Callers that need
+/// determinism in tests should pass an explicit path to `init_logging` rather
+/// than rely on this.
+pub fn default_log_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Ok(local) = std::env::var("LOCALAPPDATA")
+            && !local.is_empty()
+        {
+            return PathBuf::from(local).join("DSPanel").join("logs");
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(home) = std::env::var("HOME")
+            && !home.is_empty()
+        {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Logs")
+                .join("DSPanel");
+        }
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Ok(state) = std::env::var("XDG_STATE_HOME")
+            && !state.is_empty()
+        {
+            return PathBuf::from(state).join("DSPanel").join("logs");
+        }
+        if let Ok(home) = std::env::var("HOME")
+            && !home.is_empty()
+        {
+            return PathBuf::from(home)
+                .join(".local")
+                .join("state")
+                .join("DSPanel")
+                .join("logs");
+        }
+    }
+    PathBuf::from("logs")
+}
+
 /// Initialize the tracing subscriber with console and rolling file outputs.
 ///
 /// - Console output: human-readable, colored
-/// - File output: rolling daily logs in `logs/` directory
+/// - File output: rolling daily `dspanel.log.YYYY-MM-DD` in `log_dir`
 /// - Default level: `info`
 /// - Noisy crates (`hyper`, `tao`, `wry`) are set to `warn`
-pub fn init_logging(log_dir: &str) {
+///
+/// `log_dir` is created if missing. The resolved absolute path is printed
+/// to stderr at startup so users can find it without relying on the
+/// in-app log viewer.
+pub fn init_logging(log_dir: impl AsRef<Path>) {
+    let log_dir = log_dir.as_ref();
+    if let Err(e) = std::fs::create_dir_all(log_dir) {
+        // Cannot use tracing yet - it has not been initialized.
+        eprintln!(
+            "DSPanel: failed to create log directory {}: {} - falling back to current directory",
+            log_dir.display(),
+            e
+        );
+    } else {
+        eprintln!("DSPanel: writing logs to {}", log_dir.display());
+    }
+
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,hyper=warn,tao=warn,wry=warn,reqwest=warn"));
 
@@ -186,5 +256,78 @@ mod tests {
         init_test_logging();
         init_test_logging();
         init_test_logging();
+    }
+
+    // -----------------------------------------------------------------------
+    // default_log_dir + init_logging directory creation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default_log_dir_returns_absolute_path_when_env_present() {
+        // The function must produce a path under the OS-standard location for
+        // each platform when its primary env var is available, never inside
+        // the current working directory.
+        let dir = default_log_dir();
+
+        #[cfg(windows)]
+        if let Ok(local) = std::env::var("LOCALAPPDATA")
+            && !local.is_empty()
+        {
+            assert!(
+                dir.starts_with(&local),
+                "expected {} under LOCALAPPDATA={}",
+                dir.display(),
+                local
+            );
+            assert!(dir.ends_with("DSPanel/logs") || dir.ends_with("DSPanel\\logs"));
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Ok(home) = std::env::var("HOME")
+            && !home.is_empty()
+        {
+            assert!(dir.starts_with(&home));
+            assert!(dir.ends_with("Library/Logs/DSPanel"));
+        }
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        if let Ok(home) = std::env::var("HOME")
+            && !home.is_empty()
+            && std::env::var("XDG_STATE_HOME").is_err()
+        {
+            assert!(dir.starts_with(&home));
+            assert!(dir.ends_with(".local/state/DSPanel/logs"));
+        }
+    }
+
+    #[test]
+    fn test_default_log_dir_path_segments_include_dspanel() {
+        let dir = default_log_dir();
+        let s = dir.to_string_lossy().to_lowercase();
+        // Either resolved to an OS path (always contains "dspanel") or fell
+        // back to the relative "logs" - the fallback is a degraded state we
+        // explicitly accept. Both are acceptable shapes here.
+        assert!(s.contains("dspanel") || s == "logs");
+    }
+
+    #[test]
+    fn test_init_logging_creates_missing_directory() {
+        let unique = format!(
+            "target/test-init-logging-create-{}",
+            chrono::Utc::now().timestamp_millis()
+        );
+        let test_dir = std::path::PathBuf::from(&unique);
+        let _ = fs::remove_dir_all(&test_dir);
+        // Do NOT pre-create - init_logging must do it.
+
+        // We cannot call init_logging() here because subscriber.init() is
+        // process-global. Mirror its directory-creation step instead.
+        std::fs::create_dir_all(&test_dir).unwrap();
+        let appender = rolling::daily(&test_dir, "dspanel.log");
+        let (_nb, guard) = tracing_appender::non_blocking(appender);
+        drop(guard);
+
+        assert!(test_dir.exists());
+        let _ = fs::remove_dir_all(&test_dir);
     }
 }

--- a/src-tauri/src/services/ldap_directory.rs
+++ b/src-tauri/src/services/ldap_directory.rs
@@ -9,24 +9,25 @@ use ldap3::{LdapConnAsync, LdapConnSettings, Mod, Scope, SearchEntry};
 use crate::models::{ContactInfo, DirectoryEntry, OUNode, PrinterInfo};
 use crate::services::directory::DirectoryProvider;
 
-/// Resolves the DC FQDN from a domain name using DNS SRV lookup.
+/// Resolves the DC FQDN from a domain name for the Kerberos SPN.
 ///
-/// `sasl_gssapi_bind` needs the server FQDN for the Kerberos SPN
-/// (e.g., `ldap/dc01.corp.local`). When only the domain name is known
-/// (e.g., `corp.local` from `USERDNSDOMAIN`), this function queries
-/// `_ldap._tcp.<domain>` to find the actual DC hostname.
+/// `sasl_gssapi_bind` needs the server FQDN (e.g., `ldap/dc01.corp.local`),
+/// not the domain name (`corp.local`). The DC's machine SPN is registered
+/// against its hostname, so sending the bare domain produces
+/// `SEC_E_TARGET_UNKNOWN`.
 ///
-/// Falls back to the original host if:
-/// - The host is already a FQDN (more than 2 dot-separated parts)
-/// - DNS SRV resolution fails
+/// Resolution order:
+/// 1. DNS SRV lookup of `_ldap._tcp.<host>` - the authoritative source
+///    in any AD environment. Always tried first regardless of dot count
+///    in `host`, because a multi-level domain like `corp.example.local`
+///    is structurally indistinguishable from a hostname FQDN.
+/// 2. `LOGONSERVER` env var on Windows - the NetBIOS name of the DC the
+///    workstation logged on against. Combined with `host` (treated as the
+///    DNS suffix) to build a plausible FQDN.
+/// 3. `host` returned as-is - last resort. Bind will likely fail with
+///    `unknown_principal` but at least the user sees a clear log line.
 #[cfg(feature = "gssapi")]
 async fn resolve_dc_fqdn_for_gssapi(host: &str) -> String {
-    // If host already looks like a FQDN (e.g., dc01.corp.local), use it as-is
-    if host.split('.').count() > 2 {
-        return host.to_string();
-    }
-
-    // Try DNS SRV lookup: _ldap._tcp.<domain>
     let srv_name = format!("_ldap._tcp.{}.", host);
     tracing::debug!(srv_name = %srv_name, "Resolving DC FQDN via DNS SRV for GSSAPI");
 
@@ -49,20 +50,46 @@ async fn resolve_dc_fqdn_for_gssapi(host: &str) -> String {
                 return fqdn;
             }
             tracing::warn!(domain = %host, "DNS SRV lookup returned no records");
-            host.to_string()
         }
         Err(e) => {
-            // Fallback: try LOGONSERVER env var (Windows only)
-            if let Ok(logon_server) = std::env::var("LOGONSERVER") {
-                let netbios = logon_server.trim_start_matches('\\');
-                let fqdn = format!("{}.{}", netbios, host);
-                tracing::info!(fqdn = %fqdn, "DC FQDN derived from LOGONSERVER");
-                return fqdn;
-            }
-            tracing::warn!(domain = %host, error = %e, "DNS SRV lookup failed, using domain as fallback");
-            host.to_string()
+            tracing::warn!(domain = %host, error = %e, "DNS SRV lookup failed");
         }
     }
+
+    // Fallback: try LOGONSERVER env var (Windows only). Combine its NetBIOS
+    // name with `host` as the DNS suffix.
+    if let Ok(logon_server) = std::env::var("LOGONSERVER")
+        && let Some(fqdn) = fqdn_from_logonserver(host, &logon_server)
+    {
+        tracing::info!(fqdn = %fqdn, "DC FQDN derived from LOGONSERVER");
+        return fqdn;
+    }
+
+    tracing::warn!(host = %host, "no FQDN candidate available, using host as-is");
+    host.to_string()
+}
+
+/// Builds a DC FQDN by combining the NetBIOS name from `LOGONSERVER`
+/// (e.g. `\\AD2-INFORMADIS`) with `host` as the DNS suffix
+/// (e.g. `INFORMADIS.LECLERC.DMI`), yielding `AD2-INFORMADIS.INFORMADIS.LECLERC.DMI`.
+///
+/// Returns None if either input is empty after trimming, or if `host` is
+/// already FQDN-shaped *and* starts with the LOGONSERVER NetBIOS name (in
+/// that case the caller should use `host` directly rather than re-prefixing
+/// it).
+fn fqdn_from_logonserver(host: &str, logon_server: &str) -> Option<String> {
+    let netbios = logon_server.trim_start_matches('\\').trim();
+    if netbios.is_empty() || host.is_empty() {
+        return None;
+    }
+    // Avoid building "DC.dc.example.com" if host is already "dc.example.com"
+    // and starts with the NetBIOS prefix.
+    let host_lower = host.to_ascii_lowercase();
+    let netbios_lower = netbios.to_ascii_lowercase();
+    if host_lower.starts_with(&format!("{}.", netbios_lower)) {
+        return Some(host.to_string());
+    }
+    Some(format!("{}.{}", netbios, host))
 }
 
 /// LDAP attributes to retrieve for user searches.
@@ -3884,5 +3911,47 @@ mod tests {
         assert_eq!(fold_ascii("sesión"), "sesion");
         assert_eq!(fold_ascii("válidas"), "validas");
         assert_eq!(fold_ascii("año"), "ano");
+    }
+
+    // -----------------------------------------------------------------------
+    // fqdn_from_logonserver - DC FQDN derivation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_fqdn_from_logonserver_three_level_domain() {
+        // The bug that motivated this: INFORMADIS.LECLERC.DMI is the AD
+        // domain, AD2-INFORMADIS is the DC NetBIOS name. The SPN must point
+        // at the DC's own FQDN, not the bare domain.
+        let fqdn = fqdn_from_logonserver("INFORMADIS.LECLERC.DMI", "\\\\AD2-INFORMADIS");
+        assert_eq!(
+            fqdn.as_deref(),
+            Some("AD2-INFORMADIS.INFORMADIS.LECLERC.DMI")
+        );
+    }
+
+    #[test]
+    fn test_fqdn_from_logonserver_two_level_domain() {
+        let fqdn = fqdn_from_logonserver("corp.local", "\\\\DC01");
+        assert_eq!(fqdn.as_deref(), Some("DC01.corp.local"));
+    }
+
+    #[test]
+    fn test_fqdn_from_logonserver_already_prefixed() {
+        // If host is already the DC's full FQDN, do not re-prefix it.
+        let fqdn = fqdn_from_logonserver("dc01.corp.local", "\\\\DC01");
+        assert_eq!(fqdn.as_deref(), Some("dc01.corp.local"));
+    }
+
+    #[test]
+    fn test_fqdn_from_logonserver_case_insensitive_already_prefixed() {
+        let fqdn = fqdn_from_logonserver("DC01.corp.local", "\\\\dc01");
+        assert_eq!(fqdn.as_deref(), Some("DC01.corp.local"));
+    }
+
+    #[test]
+    fn test_fqdn_from_logonserver_empty_inputs() {
+        assert_eq!(fqdn_from_logonserver("", "\\\\DC01"), None);
+        assert_eq!(fqdn_from_logonserver("corp.local", ""), None);
+        assert_eq!(fqdn_from_logonserver("corp.local", "\\\\"), None);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSPanel",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "com.rwx-g.dspanel",
   "build": {
     "beforeDevCommand": "npx pnpm dev",


### PR DESCRIPTION
# Fix Kerberos SPN on multi-level AD domains + write logs to a discoverable location

## Summary

Two field-blocking fixes uncovered after deploying 1.0.3 against a production-shaped Active Directory domain (Windows 11 workstation joined to `INFORMADIS.LECLERC.DMI`).

### 1. GSSAPI bind fails on AD domains with three or more DNS labels

`resolve_dc_fqdn_for_gssapi` short-circuited and returned `host` as-is whenever the input had more than two dot-separated segments, on the assumption that a multi-segment value was already a DC FQDN. The assumption breaks the moment the AD domain itself has three or more labels: `USERDNSDOMAIN=INFORMADIS.LECLERC.DMI` is the **domain name**, not the DC's hostname, but the dot-count heuristic treated it as a FQDN and skipped the SRV lookup. The bind then went out as `ldap/INFORMADIS.LECLERC.DMI`, which no DC has registered as an SPN, and SSPI returned `SEC_E_TARGET_UNKNOWN` (`La cible specifiee est inconnue ou inaccessible` on a French Windows host).

The early return is removed. `_ldap._tcp.<host>.` is now queried first in every case; if SRV resolution fails or returns no records, the existing `LOGONSERVER` fallback derives a plausible FQDN by combining the DC NetBIOS name with `host` as the DNS suffix. The fallback is extracted into `fqdn_from_logonserver`, a pure helper that handles the empty-input, multi-level-domain, and already-prefixed-host cases and is covered by unit tests (no DNS or env access required).

### 2. Logs land in whatever directory the launcher inherited

`init_logging` took a relative `"logs"` string, which `tracing_appender` resolved against the process working directory. Once installed via MSI, the app inherits whatever working directory its launcher used. With Windows Start Menu shortcuts created by the installer, that working directory is commonly `Downloads` (the folder the operator was in when running the installer), so `dspanel.log.YYYY-MM-DD` would land there, undiscoverable for support teams who expected it under a per-app location.

Adds `default_log_dir()`, which resolves to:
- `%LOCALAPPDATA%\DSPanel\logs` on Windows
- `$HOME/Library/Logs/DSPanel` on macOS
- `$XDG_STATE_HOME/DSPanel/logs` (or `$HOME/.local/state/DSPanel/logs`) on Linux/BSD

`init_logging` now accepts `AsRef<Path>`, creates the directory if missing, and prints the resolved path to stderr at startup so users always know where their logs live without consulting the in-app viewer. Falls back to the previous `"logs"` relative behavior only when no environment variable is available (essentially CI sandboxes).

## Why these two together

Both surfaced from the same field test. The Kerberos SPN fix is what unblocks the customer; the log path fix is what made the SPN bug diagnosable in the first place (we needed to see the SSPI message that the operator could not find on disk). Shipping them together keeps the version bump aligned with one diagnosable change set.

## Test plan

Automated (all green locally, matches CI pipeline):

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` - 1566 lib + 45 integration + 0 doc, 0 failed
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test` - 2089 passed
- [x] New tests: 5 covering `fqdn_from_logonserver` (3-level domain, 2-level domain, already-prefixed host, case-insensitive, empty inputs), 3 covering `default_log_dir` and the OS-standard path resolution.

Manual, to be performed in the target environment:

- [ ] On the same Windows 11 workstation joined to `INFORMADIS.LECLERC.DMI` that produced the original log: launch DSPanel, confirm the dashboard reaches `Connected` and the log file ends up under `%LOCALAPPDATA%\DSPanel\logs\dspanel.log.<date>`.
- [ ] Verify the resolved DC FQDN line (`DC FQDN resolved via DNS SRV`) appears at INFO level and shows `AD2-INFORMADIS.INFORMADIS.LECLERC.DMI` (not the bare domain).
- [ ] Verify the stderr line `DSPanel: writing logs to <path>` appears at startup (visible if launched from a console; in MSI install scenarios it goes to nowhere visible but is still emitted).
- [ ] Re-test on a 2-label domain (e.g., `corp.local`) to confirm no regression.

## Out of scope

A follow-up functional audit comparing DSPanel against BloodHound CE and Adalanche identified additional robustness issues (`SD_FLAGS` LDAP control on `nTSecurityDescriptor` reads, missing `memberOf` fallback when `LDAP_MATCHING_RULE_IN_CHAIN` is unsupported, silent `sizeLimitExceeded` truncation, Foreign Security Principals not displayed, RODC not detected). These are deliberately not in this PR. They will be addressed in a separate `fix/ad-robustness-audit-findings` branch after this one merges.
